### PR TITLE
Corrected title in configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         ],
         "configuration": {
             "type": "object",
-            "title": "Example configuration",
+            "title": "Haskell Language Server",
             "properties": {
                 "languageServerHaskell.maxNumberOfProblems": {
                     "type": "number",


### PR DESCRIPTION
In the settings view, this extension's options show up under the misleading heading "Example configuration." This corrects that issue; the new heading is "Haskell Language Server."