### PR TITLE
Added Show Type command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "publisher": "alanz",
     "engines": {
-        "vscode": "^1.12.0"
+        "vscode": "^1.15.0"
     },
     "keywords": [
         "language",
@@ -114,6 +114,19 @@
                 "command": "hie.commands.insertType",
                 "title": "Haskell: Insert type",
                 "description": "Insert type for the expression"
+            },
+            {
+                "command": "hie.commands.showType",
+                "title": "Haskell: Show type",
+                "description": "Show type for the expression"
+            }
+        ],
+        "keybindings": [
+            {
+                "command": "hie.commands.showType",
+                "key": "ctrl+alt+t",
+                "mac": "cmd+alt+t",
+                "when": "editorTextFocus"
             }
         ],
         "menus": {
@@ -139,15 +152,15 @@
         "postinstall": "node ./node_modules/vscode/bin/install"
     },
     "devDependencies": {
-        "@types/mocha": "^2.2.33",
-        "@types/node": "^6.0.52",
+        "@types/mocha": ">=2.2.33",
+        "@types/node": ">=6.0.52",
         "typescript": "^2.1.5",
-        "vscode": "^1.1.0"
+        "vscode": ">1.1.0"
     },
     "extensionDependencies": [
         "justusadam.language-haskell"
     ],
     "dependencies": {
-        "vscode-languageclient": "^3.2.1"
+        "vscode-languageclient": ">3.2.0"
     }
 }

--- a/src/commands/constants.ts
+++ b/src/commands/constants.ts
@@ -1,3 +1,4 @@
 export namespace CommandNames {
   export const InsertTypeCommandName = "hie.commands.insertType";
+  export const ShowTypeCommandName = "hie.commands.showType";
 }

--- a/src/commands/showType.ts
+++ b/src/commands/showType.ts
@@ -1,0 +1,60 @@
+import { LanguageClient, RequestType } from 'vscode-languageclient';
+import { Range, Selection, OutputChannel, Disposable } from 'vscode';
+import * as lng from 'vscode-languageclient';
+import * as vscode from 'vscode';
+
+import { CommandNames } from './constants';
+
+export namespace ShowType {
+  'use strict';
+  var lastRange = new Range(0, 0, 0, 0);
+
+  export function registerCommand(client: LanguageClient): [Disposable] {
+    let showTypeChannel = vscode.window.createOutputChannel("Haskell Show Type");
+
+    let cmd = vscode.commands.registerCommand(CommandNames.ShowTypeCommandName, x => {
+      let editor = vscode.window.activeTextEditor;
+
+      let cmd = {
+        command: "ghcmod:type",
+        arguments: [{
+          file: editor.document.uri.toString(),
+          pos: editor.selections[0].start,
+          include_constraints: true
+        }]
+      };
+
+      client.sendRequest("workspace/executeCommand", cmd).then(hints => {
+        let arr = hints as [lng.Range, string][];
+        if (arr.length == 0) return;
+        let ranges = arr.map(x => [client.protocol2CodeConverter.asRange(x[0]), x[1]]) as [vscode.Range, string][];
+        let [rng, typ] = chooseRange(editor.selection, ranges);
+        lastRange = rng;
+
+        editor.selections = [new Selection(rng.end, rng.start)];
+        displayType(showTypeChannel, typ);
+      }, e => {
+        console.error(e);
+      });
+    });
+
+    return [cmd, showTypeChannel];
+  }
+
+  function chooseRange(sel: Selection, rngs: [Range, string][]): [Range, string] {
+    if (sel.isEqual(lastRange)) {
+      let curr = rngs.findIndex(([rng, typ]) => sel.isEqual(rng));
+      if (curr == -1) {
+        return rngs[0];
+      } else {
+        return rngs[Math.min(rngs.length-1, curr+1)]
+      }
+    } else return rngs[0];
+  }
+}
+
+function displayType(chan: OutputChannel, typ: string) {
+  chan.clear();
+  chan.appendLine(typ);
+  chan.show(true);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import * as msg from 'vscode-jsonrpc';
 import * as vscode from 'vscode';
 
 import { InsertType } from './commands/insertType';
+import { ShowType } from './commands/showType';
 
 // --------------------------------------------------------------------
 // Example from https://github.com/Microsoft/vscode/issues/2059
@@ -61,8 +62,8 @@ export function activate(context: ExtensionContext) {
 	// Create the language client and start the client.
 	let langClient = new LanguageClient('Language Server Haskell', serverOptions, clientOptions);
 
-	let cmd = InsertType.registerCommand(langClient);
-	context.subscriptions.push(cmd);
+	context.subscriptions.push(InsertType.registerCommand(langClient));
+	ShowType.registerCommand(langClient).forEach(x => context.subscriptions.push(x));
 
 	registerHiePointCommand(langClient,"hie.commands.demoteDef","hare:demote",context);
 	registerHiePointCommand(langClient,"hie.commands.liftOneLevel","hare:liftonelevel",context);
@@ -70,6 +71,7 @@ export function activate(context: ExtensionContext) {
 	registerHiePointCommand(langClient,"hie.commands.deleteDef","hare:deletedef",context);
 	registerHiePointCommand(langClient,"hie.commands.genApplicative","hare:genapplicative",context);
 	let disposable = langClient.start();
+
 	context.subscriptions.push(disposable);
 }
 


### PR DESCRIPTION
Added `Show type` command. 
This command returns and displays type of the "current" expression. The expression gets highlighted, and if `Show command` is called again, then it widens the scope and then shows the type of a "bigger" expression.
Default binding is set to be `Cmd+Opt+t`.

Some of it can potentially be moved to `haskell-ide-engine`, but having a feature seems useful.

![show-type](https://user-images.githubusercontent.com/1394391/30072524-f31f7c60-92ad-11e7-87b1-88bf10d7cb34.gif)
