### PR TITLE
Show docs as docs, not as sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2266 @@
+{
+    "name": "vscode-hie-server",
+    "version": "0.0.3",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@types/mocha": {
+            "version": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.41.tgz",
+            "integrity": "sha1-4nzwgXFT658nE7LT9saPHhw8pgg=",
+            "dev": true
+        },
+        "@types/node": {
+            "version": "https://registry.npmjs.org/@types/node/-/node-6.0.85.tgz",
+            "integrity": "sha1-7AK/5UphBE8r5E8Ts4nGoOjuBa4=",
+            "dev": true
+        },
+        "ajv": {
+            "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+            "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+            "dev": true,
+            "requires": {
+                "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+            }
+        },
+        "ansi-regex": {
+            "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
+        },
+        "arr-diff": {
+            "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+            "dev": true,
+            "requires": {
+                "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
+            }
+        },
+        "arr-flatten": {
+            "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+            "dev": true
+        },
+        "array-differ": {
+            "version": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+            "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+            "dev": true
+        },
+        "array-union": {
+            "version": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true,
+            "requires": {
+                "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
+            }
+        },
+        "array-uniq": {
+            "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
+        },
+        "array-unique": {
+            "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+            "dev": true
+        },
+        "arrify": {
+            "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "dev": true
+        },
+        "asn1": {
+            "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+            "dev": true
+        },
+        "assert-plus": {
+            "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+            "dev": true
+        },
+        "asynckit": {
+            "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "aws-sign2": {
+            "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+            "dev": true
+        },
+        "aws4": {
+            "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "bcrypt-pbkdf": {
+            "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+            }
+        },
+        "beeper": {
+            "version": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+            "dev": true
+        },
+        "block-stream": {
+            "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+            "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+            "dev": true,
+            "requires": {
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            }
+        },
+        "boom": {
+            "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+            "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+            "dev": true,
+            "requires": {
+                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+            }
+        },
+        "brace-expansion": {
+            "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+            "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+            "dev": true,
+            "requires": {
+                "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+            }
+        },
+        "braces": {
+            "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "dev": true,
+            "requires": {
+                "expand-range": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                "preserve": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+            }
+        },
+        "browser-stdout": {
+            "version": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+            "dev": true
+        },
+        "buffer-crc32": {
+            "version": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "dev": true
+        },
+        "caseless": {
+            "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+            "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+            "dev": true
+        },
+        "chalk": {
+            "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+        },
+        "clone": {
+            "version": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+            "dev": true
+        },
+        "clone-buffer": {
+            "version": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+            "dev": true
+        },
+        "clone-stats": {
+            "version": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+            "dev": true
+        },
+        "cloneable-readable": {
+            "version": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+            "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
+            "dev": true,
+            "requires": {
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+            }
+        },
+        "co": {
+            "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
+        "combined-stream": {
+            "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+            }
+        },
+        "commander": {
+            "version": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+            "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "convert-source-map": {
+            "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+            "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+            "dev": true
+        },
+        "core-util-is": {
+            "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "cryptiles": {
+            "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+            "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+            "dev": true,
+            "requires": {
+                "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+            }
+        },
+        "dashdash": {
+            "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "dateformat": {
+            "version": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+            "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc=",
+            "dev": true
+        },
+        "debug": {
+            "version": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+            "dev": true,
+            "requires": {
+                "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+            }
+        },
+        "deep-assign": {
+            "version": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
+            "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
+            "dev": true,
+            "requires": {
+                "is-obj": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
+            }
+        },
+        "delayed-stream": {
+            "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
+        },
+        "diff": {
+            "version": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+            "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+            "dev": true
+        },
+        "duplexer": {
+            "version": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+            "dev": true
+        },
+        "duplexer2": {
+            "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+            "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                },
+                "string_decoder": {
+                    "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                }
+            }
+        },
+        "duplexify": {
+            "version": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+            "integrity": "sha1-ThUWvmiDi8kKSZlPCzmm5ZYL780=",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                "stream-shift": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz"
+            }
+        },
+        "ecc-jsbn": {
+            "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+            }
+        },
+        "end-of-stream": {
+            "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+            "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+            "dev": true,
+            "requires": {
+                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+            }
+        },
+        "escape-string-regexp": {
+            "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "event-stream": {
+            "version": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+            "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+            "dev": true,
+            "requires": {
+                "duplexer": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+                "from": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+                "map-stream": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+                "pause-stream": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+                "split": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+                "stream-combiner": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+                "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+            }
+        },
+        "expand-brackets": {
+            "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "dev": true,
+            "requires": {
+                "is-posix-bracket": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+            }
+        },
+        "expand-range": {
+            "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "dev": true,
+            "requires": {
+                "fill-range": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
+            }
+        },
+        "extend": {
+            "version": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+            "dev": true
+        },
+        "extend-shallow": {
+            "version": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+            "dev": true,
+            "requires": {
+                "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+            }
+        },
+        "extglob": {
+            "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "dev": true,
+            "requires": {
+                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+            },
+            "dependencies": {
+                "is-extglob": {
+                    "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                }
+            }
+        },
+        "extsprintf": {
+            "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
+        },
+        "fancy-log": {
+            "version": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+            "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+            "dev": true,
+            "requires": {
+                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                "time-stamp": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz"
+            }
+        },
+        "fd-slicer": {
+            "version": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+            "dev": true,
+            "requires": {
+                "pend": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+            }
+        },
+        "filename-regex": {
+            "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+            "dev": true
+        },
+        "fill-range": {
+            "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+            "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+            "dev": true,
+            "requires": {
+                "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                "randomatic": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+                "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+            }
+        },
+        "first-chunk-stream": {
+            "version": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+            "dev": true
+        },
+        "for-in": {
+            "version": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+            "dev": true
+        },
+        "for-own": {
+            "version": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "dev": true,
+            "requires": {
+                "for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+            }
+        },
+        "forever-agent": {
+            "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+            "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+            "dev": true,
+            "requires": {
+                "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz"
+            }
+        },
+        "from": {
+            "version": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+            "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+            "dev": true
+        },
+        "fs.realpath": {
+            "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "fstream": {
+            "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+            }
+        },
+        "generate-function": {
+            "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+            "dev": true
+        },
+        "generate-object-property": {
+            "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+            "dev": true,
+            "requires": {
+                "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+            }
+        },
+        "getpass": {
+            "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "glob": {
+            "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            }
+        },
+        "glob-base": {
+            "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "dev": true,
+            "requires": {
+                "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+            },
+            "dependencies": {
+                "glob-parent": {
+                    "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+                    }
+                },
+                "is-extglob": {
+                    "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                    }
+                }
+            }
+        },
+        "glob-parent": {
+            "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+            "dev": true,
+            "requires": {
+                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                "path-dirname": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz"
+            }
+        },
+        "glob-stream": {
+            "version": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+            "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+            "dev": true,
+            "requires": {
+                "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+                "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                "ordered-read-streams": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+                "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                "to-absolute-glob": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+                "unique-stream": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                    "dev": true,
+                    "requires": {
+                        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                    }
+                },
+                "isarray": {
+                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                },
+                "string_decoder": {
+                    "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                },
+                "through2": {
+                    "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    }
+                }
+            }
+        },
+        "glogg": {
+            "version": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+            "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+            "dev": true,
+            "requires": {
+                "sparkles": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+            }
+        },
+        "graceful-fs": {
+            "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+            "dev": true
+        },
+        "graceful-readlink": {
+            "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+            "dev": true
+        },
+        "growl": {
+            "version": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+            "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+            "dev": true
+        },
+        "gulp-chmod": {
+            "version": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
+            "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
+            "dev": true,
+            "requires": {
+                "deep-assign": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
+                "stat-mode": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
+                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+            }
+        },
+        "gulp-filter": {
+            "version": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.0.1.tgz",
+            "integrity": "sha1-XYf2YuMX5YOe92UOYg5skAj/ktA=",
+            "dev": true,
+            "requires": {
+                "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+                "multimatch": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+                "streamfilter": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.5.tgz"
+            }
+        },
+        "gulp-gunzip": {
+            "version": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-0.0.3.tgz",
+            "integrity": "sha1-e24HsPWP09QlFcSOrVpj3wVy9i8=",
+            "dev": true,
+            "requires": {
+                "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                },
+                "string_decoder": {
+                    "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                },
+                "through2": {
+                    "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    }
+                },
+                "vinyl": {
+                    "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                        "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                    }
+                }
+            }
+        },
+        "gulp-remote-src": {
+            "version": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.3.tgz",
+            "integrity": "sha1-VyjP1kNDPdSEXd7wlp8PlxoqtKE=",
+            "dev": true,
+            "requires": {
+                "event-stream": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+                "node.extend": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
+                "request": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz"
+            },
+            "dependencies": {
+                "clone-stats": {
+                    "version": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "replace-ext": {
+                    "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                    "dev": true
+                },
+                "request": {
+                    "version": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+                    "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                        "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+                        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                        "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                        "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+                        "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+                        "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                        "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                        "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+                        "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                        "qs": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+                        "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+                        "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+                    }
+                },
+                "vinyl": {
+                    "version": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
+                    "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                        "clone-buffer": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+                        "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                        "cloneable-readable": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+                        "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                        "remove-trailing-separator": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+                        "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz"
+                    }
+                }
+            }
+        },
+        "gulp-sourcemaps": {
+            "version": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+            "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+            "dev": true,
+            "requires": {
+                "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
+            },
+            "dependencies": {
+                "vinyl": {
+                    "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                        "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                        "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                    }
+                }
+            }
+        },
+        "gulp-symdest": {
+            "version": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
+            "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
+            "dev": true,
+            "requires": {
+                "event-stream": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                "queue": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
+                "vinyl-fs": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz"
+            }
+        },
+        "gulp-untar": {
+            "version": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.6.tgz",
+            "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
+            "dev": true,
+            "requires": {
+                "event-stream": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+                "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+                "streamifier": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
+                "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+            }
+        },
+        "gulp-util": {
+            "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+            "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+            "dev": true,
+            "requires": {
+                "array-differ": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+                "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+                "beeper": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+                "fancy-log": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+                "gulplog": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+                "has-gulplog": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+                "lodash._reescape": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+                "lodash._reevaluate": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+                "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+                "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+                "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                "multipipe": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+                "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
+            }
+        },
+        "gulp-vinyl-zip": {
+            "version": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-1.4.0.tgz",
+            "integrity": "sha1-VjgvLMtXIxuwR4x4c3zNVylzvuE=",
+            "dev": true,
+            "requires": {
+                "event-stream": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+                "queue": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
+                "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                "vinyl-fs": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+                "yauzl": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz",
+                "yazl": "https://registry.npmjs.org/yazl/-/yazl-2.4.2.tgz"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                },
+                "string_decoder": {
+                    "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                },
+                "through2": {
+                    "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    }
+                },
+                "vinyl": {
+                    "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                        "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                    }
+                }
+            }
+        },
+        "gulplog": {
+            "version": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+            "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+            "dev": true,
+            "requires": {
+                "glogg": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
+            }
+        },
+        "har-schema": {
+            "version": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+            "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+            "dev": true
+        },
+        "har-validator": {
+            "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+            "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+            "dev": true,
+            "requires": {
+                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                "commander": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+                "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+            }
+        },
+        "has-ansi": {
+            "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+            }
+        },
+        "has-flag": {
+            "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+            "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+            "dev": true
+        },
+        "has-gulplog": {
+            "version": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+            "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+            "dev": true,
+            "requires": {
+                "sparkles": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+            }
+        },
+        "hawk": {
+            "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+            "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+            "dev": true,
+            "requires": {
+                "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+            }
+        },
+        "hoek": {
+            "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+            "dev": true
+        },
+        "http-signature": {
+            "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+            "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+                "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz"
+            }
+        },
+        "inflight": {
+            "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+            }
+        },
+        "inherits": {
+            "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "is": {
+            "version": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
+            "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
+            "dev": true
+        },
+        "is-buffer": {
+            "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+            "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+            "dev": true
+        },
+        "is-dotfile": {
+            "version": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+            "dev": true
+        },
+        "is-equal-shallow": {
+            "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "dev": true,
+            "requires": {
+                "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+            }
+        },
+        "is-extendable": {
+            "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+            "dev": true
+        },
+        "is-extglob": {
+            "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+            "dev": true,
+            "requires": {
+                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
+            }
+        },
+        "is-my-json-valid": {
+            "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+            "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+            "dev": true,
+            "requires": {
+                "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+                "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+            }
+        },
+        "is-number": {
+            "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "dev": true,
+            "requires": {
+                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+            }
+        },
+        "is-obj": {
+            "version": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+            "dev": true
+        },
+        "is-posix-bracket": {
+            "version": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+            "dev": true
+        },
+        "is-primitive": {
+            "version": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+            "dev": true
+        },
+        "is-property": {
+            "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+            "dev": true
+        },
+        "is-stream": {
+            "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
+        },
+        "is-typedarray": {
+            "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "is-utf8": {
+            "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "dev": true
+        },
+        "is-valid-glob": {
+            "version": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+            "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
+        },
+        "isobject": {
+            "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+            "dev": true,
+            "requires": {
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            }
+        },
+        "isstream": {
+            "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
+        "jsbn": {
+            "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true,
+            "optional": true
+        },
+        "json-schema": {
+            "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
+        },
+        "json-stable-stringify": {
+            "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "dev": true,
+            "requires": {
+                "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+            }
+        },
+        "json-stringify-safe": {
+            "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
+        },
+        "json3": {
+            "version": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+            "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+            "dev": true
+        },
+        "jsonify": {
+            "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
+        "jsonpointer": {
+            "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+            "dev": true
+        },
+        "jsprim": {
+            "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+                "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                "verror": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "kind-of": {
+            "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "dev": true,
+            "requires": {
+                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+            }
+        },
+        "lazystream": {
+            "version": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+            }
+        },
+        "lodash._baseassign": {
+            "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+            "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+            "dev": true,
+            "requires": {
+                "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+            }
+        },
+        "lodash._basecopy": {
+            "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+            "dev": true
+        },
+        "lodash._basecreate": {
+            "version": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+            "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+            "dev": true
+        },
+        "lodash._basetostring": {
+            "version": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+            "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+            "dev": true
+        },
+        "lodash._basevalues": {
+            "version": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+            "dev": true
+        },
+        "lodash._getnative": {
+            "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+            "dev": true
+        },
+        "lodash._isiterateecall": {
+            "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+            "dev": true
+        },
+        "lodash._reescape": {
+            "version": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+            "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+            "dev": true
+        },
+        "lodash._reevaluate": {
+            "version": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+            "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+            "dev": true
+        },
+        "lodash._reinterpolate": {
+            "version": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+            "dev": true
+        },
+        "lodash._root": {
+            "version": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+            "dev": true
+        },
+        "lodash.create": {
+            "version": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+            "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+            "dev": true,
+            "requires": {
+                "lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                "lodash._basecreate": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+                "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+            }
+        },
+        "lodash.escape": {
+            "version": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+            "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+            "dev": true,
+            "requires": {
+                "lodash._root": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+            }
+        },
+        "lodash.isarguments": {
+            "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+            "dev": true
+        },
+        "lodash.isarray": {
+            "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+            "dev": true
+        },
+        "lodash.isequal": {
+            "version": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+            "dev": true
+        },
+        "lodash.keys": {
+            "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+            "dev": true,
+            "requires": {
+                "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                "lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+            }
+        },
+        "lodash.restparam": {
+            "version": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+            "dev": true
+        },
+        "lodash.template": {
+            "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+            "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+            "dev": true,
+            "requires": {
+                "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                "lodash._basetostring": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                "lodash._basevalues": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+                "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+                "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+                "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                "lodash.restparam": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
+            }
+        },
+        "lodash.templatesettings": {
+            "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+            "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+            "dev": true,
+            "requires": {
+                "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+                "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz"
+            }
+        },
+        "map-stream": {
+            "version": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+            "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+            "dev": true
+        },
+        "merge-stream": {
+            "version": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+            }
+        },
+        "micromatch": {
+            "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "dev": true,
+            "requires": {
+                "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                "braces": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                "expand-brackets": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                "extglob": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                "filename-regex": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                "parse-glob": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                "regex-cache": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
+            },
+            "dependencies": {
+                "is-extglob": {
+                    "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                    }
+                }
+            }
+        },
+        "mime-db": {
+            "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
+            "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+            "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+            "dev": true,
+            "requires": {
+                "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+            }
+        },
+        "minimatch": {
+            "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
+            }
+        },
+        "minimist": {
+            "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "requires": {
+                "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
+                }
+            }
+        },
+        "mocha": {
+            "version": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+            "integrity": "sha1-EyhWfScX+ZcDD4AGI0vOm4zXJGU=",
+            "dev": true,
+            "requires": {
+                "browser-stdout": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+                "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                "growl": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+                "json3": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+                "lodash.create": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                    "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    }
+                },
+                "glob": {
+                    "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                    "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                    }
+                },
+                "supports-color": {
+                    "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+                    "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                    }
+                }
+            }
+        },
+        "ms": {
+            "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "multimatch": {
+            "version": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+            "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+            "dev": true,
+            "requires": {
+                "array-differ": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+                "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+                "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+            }
+        },
+        "multipipe": {
+            "version": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+            "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+            "dev": true,
+            "requires": {
+                "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
+            }
+        },
+        "node.extend": {
+            "version": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
+            "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
+            "dev": true,
+            "requires": {
+                "is": "https://registry.npmjs.org/is/-/is-3.2.1.tgz"
+            }
+        },
+        "normalize-path": {
+            "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "dev": true,
+            "requires": {
+                "remove-trailing-separator": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
+            }
+        },
+        "oauth-sign": {
+            "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+            "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+            "dev": true
+        },
+        "object.omit": {
+            "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "dev": true,
+            "requires": {
+                "for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+            }
+        },
+        "once": {
+            "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+            }
+        },
+        "ordered-read-streams": {
+            "version": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+            "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+            "dev": true,
+            "requires": {
+                "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+            }
+        },
+        "parse-glob": {
+            "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "dev": true,
+            "requires": {
+                "glob-base": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                "is-dotfile": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+            },
+            "dependencies": {
+                "is-extglob": {
+                    "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                    }
+                }
+            }
+        },
+        "path-dirname": {
+            "version": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "pause-stream": {
+            "version": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+            "dev": true,
+            "requires": {
+                "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+            }
+        },
+        "pend": {
+            "version": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+            "dev": true
+        },
+        "performance-now": {
+            "version": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+            "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
+            "requires": {
+                "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+            }
+        },
+        "preserve": {
+            "version": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+            "dev": true
+        },
+        "punycode": {
+            "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+            "dev": true
+        },
+        "qs": {
+            "version": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+            "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+            "dev": true
+        },
+        "querystringify": {
+            "version": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+            "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
+            "dev": true
+        },
+        "queue": {
+            "version": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
+            "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
+            "dev": true,
+            "requires": {
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            }
+        },
+        "randomatic": {
+            "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+            "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
+            "dev": true,
+            "requires": {
+                "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                            }
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                    }
+                }
+            }
+        },
+        "readable-stream": {
+            "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+            "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+            "dev": true,
+            "requires": {
+                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+            }
+        },
+        "regex-cache": {
+            "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+            "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+            "dev": true,
+            "requires": {
+                "is-equal-shallow": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+            }
+        },
+        "remove-trailing-separator": {
+            "version": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+            "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+            "dev": true
+        },
+        "repeat-element": {
+            "version": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+            "dev": true
+        },
+        "repeat-string": {
+            "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
+        },
+        "replace-ext": {
+            "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+            "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+            "dev": true
+        },
+        "request": {
+            "version": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+            "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+                "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+                "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+                "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+                "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                "performance-now": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+                "qs": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+                "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+                "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+            },
+            "dependencies": {
+                "caseless": {
+                    "version": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+                    "dev": true
+                },
+                "har-validator": {
+                    "version": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+                    "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                        "har-schema": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+                    }
+                },
+                "qs": {
+                    "version": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+                    "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+                    "dev": true
+                },
+                "tunnel-agent": {
+                    "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                    "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                    }
+                }
+            }
+        },
+        "requires-port": {
+            "version": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+            "dev": true
+        },
+        "rimraf": {
+            "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+            "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+            "dev": true,
+            "requires": {
+                "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+            }
+        },
+        "safe-buffer": {
+            "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
+            "dev": true
+        },
+        "semver": {
+            "version": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+            "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
+            "dev": true
+        },
+        "sntp": {
+            "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+            "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+            "dev": true,
+            "requires": {
+                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+            }
+        },
+        "source-map": {
+            "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+            "dev": true
+        },
+        "source-map-support": {
+            "version": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
+            "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+            "dev": true,
+            "requires": {
+                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            }
+        },
+        "sparkles": {
+            "version": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+            "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+            "dev": true
+        },
+        "split": {
+            "version": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+            "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+            "dev": true,
+            "requires": {
+                "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+            }
+        },
+        "sshpk": {
+            "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+            "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+            "dev": true,
+            "requires": {
+                "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "stat-mode": {
+            "version": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
+            "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
+            "dev": true
+        },
+        "stream-combiner": {
+            "version": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+            "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+            "dev": true,
+            "requires": {
+                "duplexer": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+            }
+        },
+        "stream-shift": {
+            "version": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+            "dev": true
+        },
+        "streamfilter": {
+            "version": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.5.tgz",
+            "integrity": "sha1-h1BxEb644phFFxe1Ec/tjwAqv1M=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+            }
+        },
+        "streamifier": {
+            "version": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
+            "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=",
+            "dev": true
+        },
+        "string_decoder": {
+            "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+            "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+            }
+        },
+        "stringstream": {
+            "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+            "dev": true
+        },
+        "strip-ansi": {
+            "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+            }
+        },
+        "strip-bom": {
+            "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+            "dev": true,
+            "requires": {
+                "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+            }
+        },
+        "strip-bom-stream": {
+            "version": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+            "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+            "dev": true,
+            "requires": {
+                "first-chunk-stream": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+                "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+            }
+        },
+        "supports-color": {
+            "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "dev": true
+        },
+        "tar": {
+            "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+            "dev": true,
+            "requires": {
+                "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+                "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            }
+        },
+        "through": {
+            "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "through2": {
+            "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+            }
+        },
+        "through2-filter": {
+            "version": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+            "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+            "dev": true,
+            "requires": {
+                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+            }
+        },
+        "time-stamp": {
+            "version": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+            "dev": true
+        },
+        "to-absolute-glob": {
+            "version": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+            "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
+            }
+        },
+        "tough-cookie": {
+            "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+            "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+            "dev": true,
+            "requires": {
+                "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+            }
+        },
+        "tunnel-agent": {
+            "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+            "dev": true
+        },
+        "tweetnacl": {
+            "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true,
+            "optional": true
+        },
+        "typescript": {
+            "version": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
+            "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
+            "dev": true
+        },
+        "unique-stream": {
+            "version": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+            "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+            "dev": true,
+            "requires": {
+                "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                "through2-filter": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz"
+            }
+        },
+        "url-parse": {
+            "version": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
+            "integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
+            "dev": true,
+            "requires": {
+                "querystringify": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+                "requires-port": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+            }
+        },
+        "util-deprecate": {
+            "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "uuid": {
+            "version": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+            "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
+            "dev": true
+        },
+        "vali-date": {
+            "version": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+            "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+            "dev": true
+        },
+        "verror": {
+            "version": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "vinyl": {
+            "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+            "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+            "dev": true,
+            "requires": {
+                "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            }
+        },
+        "vinyl-fs": {
+            "version": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+            "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+            "dev": true,
+            "requires": {
+                "duplexify": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+                "glob-stream": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                "gulp-sourcemaps": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+                "is-valid-glob": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+                "lazystream": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+                "lodash.isequal": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+                "merge-stream": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                "strip-bom-stream": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                "through2-filter": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+                "vali-date": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+                "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
+            },
+            "dependencies": {
+                "object-assign": {
+                    "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                        "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                        "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                    }
+                }
+            }
+        },
+        "vinyl-source-stream": {
+            "version": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
+            "integrity": "sha1-RMvlEIIFJ53rDFZTwJSiiHk4sas=",
+            "dev": true,
+            "requires": {
+                "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                },
+                "string_decoder": {
+                    "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                },
+                "through2": {
+                    "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    }
+                },
+                "vinyl": {
+                    "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                        "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                    }
+                }
+            }
+        },
+        "vscode": {
+            "version": "https://registry.npmjs.org/vscode/-/vscode-1.1.4.tgz",
+            "integrity": "sha1-Hx1NZi1VyaKLxGeqy2MikfcKaG0=",
+            "dev": true,
+            "requires": {
+                "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                "gulp-chmod": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
+                "gulp-filter": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.0.1.tgz",
+                "gulp-gunzip": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-0.0.3.tgz",
+                "gulp-remote-src": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.3.tgz",
+                "gulp-symdest": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
+                "gulp-untar": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.6.tgz",
+                "gulp-vinyl-zip": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-1.4.0.tgz",
+                "mocha": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+                "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+                "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+                "source-map-support": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
+                "url-parse": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
+                "vinyl-source-stream": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz"
+            }
+        },
+        "vscode-jsonrpc": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.4.1.tgz",
+            "integrity": "sha1-4uC54SH3GitUSAWKNKOu+DdqXpE="
+        },
+        "vscode-languageclient": {
+            "version": "3.4.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-3.4.5.tgz",
+            "integrity": "sha1-YjAHKrB3IIXQm0j5m3nnxCHd+7c=",
+            "requires": {
+                "vscode-languageserver-protocol": "3.4.4"
+            }
+        },
+        "vscode-languageserver-protocol": {
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.4.4.tgz",
+            "integrity": "sha1-A4e7Sb0PgF6QSMaVmX29Qw1uyig=",
+            "requires": {
+                "vscode-jsonrpc": "3.4.1",
+                "vscode-languageserver-types": "3.4.0"
+            }
+        },
+        "vscode-languageserver-types": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.4.0.tgz",
+            "integrity": "sha1-UEOuR+5KwWrwe7PQylYSNeDA0vo="
+        },
+        "wrappy": {
+            "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "xtend": {
+            "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "dev": true
+        },
+        "yauzl": {
+            "version": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz",
+            "integrity": "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=",
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+                "fd-slicer": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+            }
+        },
+        "yazl": {
+            "version": "https://registry.npmjs.org/yazl/-/yazl-2.4.2.tgz",
+            "integrity": "sha1-FMsZCD4eJacAksFYiqvg9OTdTYg=",
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "publisher": "alanz",
     "engines": {
-        "vscode": "^1.15.0"
+        "vscode": "^1.17.2"
     },
     "keywords": [
         "language",
@@ -161,6 +161,6 @@
         "justusadam.language-haskell"
     ],
     "dependencies": {
-        "vscode-languageclient": ">3.2.0"
+        "vscode-languageclient": ">=3.4.5"
     }
 }

--- a/src/docsBrowser.ts
+++ b/src/docsBrowser.ts
@@ -1,0 +1,60 @@
+import * as vscode from 'vscode';
+import { ProvideHoverSignature } from 'vscode-languageclient';
+import { workspace, Disposable, ExtensionContext, languages, commands,
+    MarkedString, MarkdownString, TextDocument, CancellationToken,
+    Position as VPosition, ProviderResult, Hover as VHover } from 'vscode';
+
+
+export namespace DocsBrowser {
+    'use strict';
+
+    //registers the browser in VSCode infrastructure
+    export function registerDocsBrowser(): Disposable {
+        class DocumentationContentProvider implements vscode.TextDocumentContentProvider {
+            provideTextDocumentContent(uri: vscode.Uri, token: vscode.CancellationToken): string {
+                let fsUri = uri.with({scheme: "file"});
+                return `<iframe src="${fsUri}" frameBorder="0" style="background: white; width: 100%; height: 100%; position:absolute; left: 0; right: 0; bottom: 0; top: 0px;" />`;
+            }
+        }
+        let provider = new DocumentationContentProvider();
+
+        let docPreviewReg = vscode.workspace.registerTextDocumentContentProvider('doc-preview', provider);
+
+        let disposable = vscode.commands.registerCommand('haskell.showDocumentation', ({ title, path }: { title: string, path: string }) => {
+            let uri = vscode.Uri.parse(path).with({scheme: 'doc-preview'});
+            let arr = uri.path.match(/([^\/]+)\.[^.]+$/);
+            let ttl = arr.length == 2 ? arr[1].replace(/-/gi, ".") : title;
+            return vscode.commands.executeCommand('vscode.previewHtml', uri, vscode.ViewColumn.Two, ttl).then((success) => {
+            }, (reason) => {
+                vscode.window.showErrorMessage(reason);
+            });
+        });
+
+        return disposable;
+    }
+
+    export function hoverLinksMiddlewareHook(document: TextDocument, position: VPosition, token: CancellationToken, next: ProvideHoverSignature): ProviderResult<VHover> {
+        const res = next(document, position, token);
+        return Promise.resolve(res).then(r => {
+            r.contents = r.contents.map(processLink);
+            return r;
+        });
+    }
+
+    function processLink(ms: MarkedString): MarkedString {
+        function transform(s: string): string {
+             return s.replace(/\[(.+)\]\((file:.+\/doc\/.+\.html#?.+)\)/ig, (all, title, path) => {
+                let encoded = encodeURIComponent(JSON.stringify({title: title, path: path}));
+                let cmd = 'command:haskell.showDocumentation?' + encoded;
+                return `[${title}](${cmd})`;
+            });
+        }
+        if (typeof ms === 'string') {
+            let mstr = new MarkdownString(transform(ms));
+            mstr.isTrusted = true;
+            return mstr;
+        } else {
+            return ms;
+        }
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import * as vscode from 'vscode';
 
 import { InsertType } from './commands/insertType';
 import { ShowType } from './commands/showType';
+import { DocsBrowser } from './docsBrowser';
 
 // --------------------------------------------------------------------
 // Example from https://github.com/Microsoft/vscode/issues/2059
@@ -51,6 +52,10 @@ export async function activate(context: ExtensionContext) {
 }
 
 function activateNoHieCheck(context: ExtensionContext) {
+
+	let docsDisposable = DocsBrowser.registerDocsBrowser();
+	context.subscriptions.push(docsDisposable);
+
 	// const fixer = languages.registerCodeActionsProvider("haskell", fixProvider);
 	// context.subscriptions.push(fixer);
 	// The server is implemented in node
@@ -80,6 +85,9 @@ function activateNoHieCheck(context: ExtensionContext) {
 			configurationSection: 'languageServerHaskell',
 			// Notify the server about file changes to '.clientrc files contain in the workspace
 			fileEvents: workspace.createFileSystemWatcher('**/.clientrc')
+		},
+		middleware: {
+			provideHover: DocsBrowser.hoverLinksMiddlewareHook
 		}
 	}
 


### PR DESCRIPTION
## Changes

`HIE` provides very useful links to documentation and source in a hover popup. Unfortunately, `VSCode` now opens these links in its tabs as HTML source, not as readable documentation.
The issue was tracked in https://github.com/Microsoft/vscode/issues/36452 with the resolution that this behaviour is expected.

This PR fixes the issue by opening haddock docs and sources in a human-readable form:

![show-docs](https://user-images.githubusercontent.com/1394391/32080525-e482ac74-bafb-11e7-85a2-33658566fbfb.gif)

