### PR TITLE
Stop the output window from taking focus

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,7 +88,8 @@ function activateNoHieCheck(context: ExtensionContext) {
 		},
 		middleware: {
 			provideHover: DocsBrowser.hoverLinksMiddlewareHook
-		}
+		},
+		revealOutputChannelOn: RevealOutputChannelOn.never
 	}
 
 	// Create the language client and start the client.


### PR DESCRIPTION
Seems I wasn't the only one annoyed with the output window constantly getting focus, as per https://github.com/angular/vscode-ng-language-service/issues/128, https://github.com/Microsoft/vscode/issues/36844 and many more.

According to https://github.com/emberwatch/vscode-ember/issues/2 it seems setting `revealOutputChannelOn: RevealOutputChannelOn.never` will stop the output window from taking over focus.