### PR TITLE
Set marketplace banner colors and theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
         "Languages"
     ],
     "icon": "images/HaskellLogo.png",
+    "galleryBanner": {
+        "color": "#22172A",
+        "theme": "dark"
+    },
     "activationEvents": [
         "onLanguage:haskell",
         "onLanguage:literate haskell"


### PR DESCRIPTION
Sets the banner color to a dark purple, ala what we use on Haskell.org, and the theme to dark. This is merely a suggestion, but thought it'd make it would give it a bit more lively look :)