### PR TITLE
Polish the README and other documentation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,22 @@
+### 0.0.4
+
+Show documents in a tab, by @AlexeyRaga
+
+Add a configuration option to enable/disable `hlint`.
+
+### 0.0.3
+
+Add "Haskell: Show type" command, bound to Ctrl-alt-t (Cmd-alt-t on mac). This
+calls the `ghc-mod` `type` command on the current cursor location or highlighted
+region. Thanks to @AlexeyRaga
+
+Add a check for having the `hie` executable in the path on startup, to prevent
+an endless failure to start if the executable is not there. Thanks to @DavidEichman
+
+### 0.0.2
+
+Add some HaRe commands, accesible via the command palette.
+
+### 0.0.1
+
+Initial release of haskell-ide-engine VS Code extension, for brave pioneers.

--- a/Contributing.md
+++ b/Contributing.md
@@ -1,4 +1,35 @@
-# Welcome to your first VS Code Extension
+# Contributing
+
+This document will briefly outline how to get started contributing to the `vscode-hie-server` Haskell language client for the [Haskell-IDE-Engine](https://github.com/haskell/haskell-ide-engine) language server.
+
+## Dependencies and Building
+
+For development, all you need is to,
+
+- run `npm install -g typescript` to get TypeScript,
+- then run `npm install` in the project root to install development dependencies.
+
+You can now also package up the extension with,
+
+- `vsce package` 
+
+which creates an extension package at `vscode-hie-server-<version>.vsix`.
+
+_Note:_ that if you get errors running `vsce package`, it might help running `tsc -p ./` directly, since that gives the actual error output of the TypeScript compilation.
+
+## Developing
+* Launch VS Code, press `File` > `Open Folder`, open the `vscode-hie-server` folder;
+* press `F5` to open a new window with the `vscode-hie-server` loaded (this will overwrite existing ones, e.g. from the marketplace);
+* open a Haskell file with the __new__ editor to test the LSP client;
+
+You are now ready to make changes and debug. You can,
+
+* set breakpoints in your code inside `src/extension.ts` to debug your extension;
+* find output from your extension in the debug console;
+* make changes to the code, and then
+* relaunch the extension from the debug toolbar
+
+_Note_: you can also reload (`Ctrl+R` or `Cmd+R` on macOS) the VS Code window with your extension to load your changes
 
 ## What's in the folder
 * This folder contains all of the files necessary for your extension
@@ -10,16 +41,6 @@ The file exports one function, `activate`, which is called the very first time y
 activated (in this case by executing the command). Inside the `activate` function we call `registerCommand`.
 We pass the function containing the implementation of the command as the second parameter to
 `registerCommand`.
-
-## Get up and running straight away
-* press `F5` to open a new window with your extension loaded
-* run your command from the command palette by pressing (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) and typing `Hello World`
-* set breakpoints in your code inside `src/extension.ts` to debug your extension
-* find output from your extension in the debug console
-
-## Make changes
-* you can relaunch the extension from the debug toolbar after changing code in `src/extension.ts`
-* you can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes
 
 ## Explore the API
 * you can open the full set of our API when you open the file `node_modules/vscode/vscode.d.ts`

--- a/Contributing.md
+++ b/Contributing.md
@@ -31,21 +31,17 @@ You are now ready to make changes and debug. You can,
 
 _Note_: you can also reload (`Ctrl+R` or `Cmd+R` on macOS) the VS Code window with your extension to load your changes
 
-## What's in the folder
-* This folder contains all of the files necessary for your extension
-* `package.json` - this is the manifest file in which you declare your extension and command.
-The sample plugin registers a command and defines its title and command name. With this information
-VS Code can show the command in the command palette. It doesn’t yet need to load the plugin.
-* `src/extension.ts` - this is the main file where you will provide the implementation of your command.
-The file exports one function, `activate`, which is called the very first time your extension is
-activated (in this case by executing the command). Inside the `activate` function we call `registerCommand`.
-We pass the function containing the implementation of the command as the second parameter to
-`registerCommand`.
+## Navigating the Files
+A brief overview of the files,
+* `package.json` contains the basic information about the package, see [the full manifest for more](https://code.visualstudio.com/docs/extensionAPI/extension-manifest), such as telling VS Code which scope the LSP works on (Haskell and Literate Haskell in our case), and possible configuration
+* `src/extension.ts` handles activating and deactivating the HIE language server, along with checking if HIE is installed
+* `src/docsBrowser.ts` contains the logic for displaying the documentation browser
 
-## Explore the API
-* you can open the full set of our API when you open the file `node_modules/vscode/vscode.d.ts`
+## Helpful Reading Material
 
-## Run tests
+We recommend checking out [Your First VS Code Extension](https://code.visualstudio.com/docs/extensions/example-hello-world) and [Creating a Language Server](https://code.visualstudio.com/docs/extensions/example-language-server) for some introduction to VS Code extensions.
+
+## Running tests
 * open the debug viewlet (`Ctrl+Shift+D` or `Cmd+Shift+D` on Mac) and from the launch configuration dropdown pick `Launch Tests`
 * press `F5` to run the tests in a new window with your extension loaded
 * see the output of the test result in the debug console

--- a/Contributing.md
+++ b/Contributing.md
@@ -1,9 +1,7 @@
 # Contributing
-
 This document will briefly outline how to get started contributing to the `vscode-hie-server` Haskell language client for the [Haskell-IDE-Engine](https://github.com/haskell/haskell-ide-engine) language server.
 
 ## Dependencies and Building
-
 For development, all you need is to,
 
 - run `npm install -g typescript` to get TypeScript,
@@ -35,10 +33,12 @@ _Note_: you can also reload (`Ctrl+R` or `Cmd+R` on macOS) the VS Code window wi
 A brief overview of the files,
 * `package.json` contains the basic information about the package, see [the full manifest for more](https://code.visualstudio.com/docs/extensionAPI/extension-manifest), such as telling VS Code which scope the LSP works on (Haskell and Literate Haskell in our case), and possible configuration
 * `src/extension.ts` handles activating and deactivating the HIE language server, along with checking if HIE is installed
-* `src/docsBrowser.ts` contains the logic for displaying the documentation browser
+* `src/docsBrowser.ts` contains the logic for displaying the documentation browser (e.g. hover over a type like `mapM_` and click `Documentation` or `Source`)
+* `src/commands/constants.ts` simply exports the rest of the commands in folder
+* `src/commands/showType.ts` handles showing a type using `ghcmod:type`
+* `src/commands/insertType.ts` handles inserting a type using the output of `ghcmod:type`
 
 ## Helpful Reading Material
-
 We recommend checking out [Your First VS Code Extension](https://code.visualstudio.com/docs/extensions/example-hello-world) and [Creating a Language Server](https://code.visualstudio.com/docs/extensions/example-language-server) for some introduction to VS Code extensions.
 
 ## Running tests

--- a/README.md
+++ b/README.md
@@ -1,75 +1,61 @@
-# Haskell Language Server
+# Haskell Language Server Client
+Client interface to the Language Server Protocol server for Haskell, as provided by the Haskell IDE Engine. Check the [requirements](#user-content-requirements) for dependencies.
 
-[Available on the VSCode marketplace](https://marketplace.visualstudio.com/items?itemName=alanz.vscode-hie-server)
+__It is still under development!__ If you want to help, get started by reading [Contributing](https://github.com/alanz/vscode-hie-server/blob/master/Contributing.md) for more details.
 
-Client interface to the Language Server Protocol server for Haskell, as provided by the Haskell IDE Engine.
-
-It is still under development.
-
-To make use of it, do the following
+## Requirements
+The language client requires you to manually install the [HIE](https://github.com/haskell/haskell-ide-engine) language server,
 
 ```bash
-git clone https://github.com/haskell/haskell-ide-engine
-cd haskell-ide-engine
-stack install
+$ git clone https://github.com/haskell/haskell-ide-engine
+$ cd haskell-ide-engine
+$ stack install
 ```
 
-Also, make sure the extension is installed in vscode, either via the
-marketplace (preferred), or if you are testing an unreleased version by
+## Features
+Language server client for haskell using the [HIE](https://github.com/haskell/haskell-ide-engine) language server. Supports,
+
+- Diagnostics via HLint and GHC warnings/errors
+- Code actions and quick-fixes via [`apply-refact`](https://github.com/mpickering/apply-refact) (click the lightbulb)
+- Type information and documentation (via hoogle) on hover
+- Jump to definition (`F12` or `Go to Definition` in command palette)
+- List all top level definitions
+- Highlight references in document
+- Completion
+- Formatting via [`brittany`](https://github.com/lspitzner/brittany) (`^ ⌥ B` or `Format Document` in command palette)
+- Renaming via [`HaRe`](https://github.com/alanz/HaRe) (`F2` or `Rename Symbol` in command palette)
+
+Additionally the language server itself features,
+- Supports plain GHC projects, cabal projects (sandboxed and non sandboxed) and stack projects
+- Fast due to caching of compile info
+
+## Extension Settings
+You can disable HLint and also control the maximum number of reported problems,
+
+```json
+"languageServerHaskell.hlintOn": true,
+"languageServerHaskell.maxNumberOfProblems": 100,
+```
+## Manual Installation
+Either install the extension via the marketplace (preferred), or if you are testing an unreleased version by,
 
 ```bash
 $ npm install -g vsce
+$ git clone https://github.com/alanz/vscode-hie-server
+$ cd vscode-hie-server
+$ npm install
 $ vsce package
 ```
 
-This will create a file something like `vscode-hie-server-0.0.3.vsix`
+This will create a file something like `vscode-hie-server-<version>.vsix`
 according to the current version.
 
-In vscode, open the extensions tab, and click on the `...` at the top right of it,
+In VS Code, open the extensions tab, and click on the `...` at the top right of it,
 and use the `Install from VSIX...` option to locate and install the generated file.
 
-## Features
-
-Language server client for haskell.
-
-## Requirements
-
-If you have any requirements or dependencies, add a section describing those and
-how to install and configure them.
-
-## Extension Settings
-
-Include if your extension adds any VS Code settings through the
-`contributes.configuration` extension point.
-
-None at present
-
 ## Known Issues
-
-Only works for GHC 8.0.2 projects at the moment
+Only works for GHC 8.0.2 projects at the moment.
 
 ## Release Notes
 
-### 0.0.4
-
-Show documents in a tab, by @AlexeyRaga
-
-Add a configuration option to enable/disable `hlint`.
-
-### 0.0.3
-
-Add "Haskell: Show type" command, bound to Ctrl-alt-t (Cmd-alt-t on mac). This
-calls the `ghc-mod` `type` command on the current cursor location or highlighted
-region. Thanks to @AlexeyRaga
-
-Add a check for having the `hie` executable in the path on startup, to prevent
-an endless failure to start if the executable is not there. Thanks to @DavidEichman
-
-### 0.0.2
-
-Add some HaRe commands, accesible via the command palette.
-
-### 0.0.1
-
-Initial release of haskell-ide-engine vscode extension, for brave pioneers.
-
+See the [Changelog](https://github.com/alanz/vscode-hie-server/blob/master/Changelog.md) for more details.


### PR DESCRIPTION
Updated the README a bit to look better on the VS Code marketplace. Also added a Contributing.md taking over  the generic `vsc-extension-quickstart.md`, and move changelog information out into a separate file.