### PR TITLE
Set up travis initial deployment script and testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 out
 node_modules
+.vscode-test
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,22 +44,23 @@ before_deploy:
 #      b) Set a environment variable `VS_TOKEN` with the value of your VS Code personal token
 #      c) Make sure `Display value in build log` is turned OFF!
 deploy:
-- provider: releases # Deploy the *.vsix pcakge to GitHub releases.
-  file_glob: true
-  file: "*.vsix"
-  skip_cleanup: true
-  on: # Due to a limitation with releases, we can only deploy them on tags.
-    repo: alanz/vscode-hie-server
-    branch: master
-    tags: true
-    condition: $TRAVIS_OS_NAME = linux
-- provider: script # Deploy to VS Code Market Place
+- provider: script # Deploy to VS Code Market Place (only on tags!).
   script: vsce publish -p $VS_TOKEN
   skip_cleanup: true
   on: # Publish on all builds on master branch.
     repo: alanz/vscode-hie-server
     branch: master
+    tags: true
     condition: $TRAVIS_OS_NAME = linux
+# - provider: releases # Deploy the *.vsix pcakge to GitHub releases.
+#   file_glob: true
+#   file: "*.vsix"
+#   skip_cleanup: true
+#   on: # Due to a limitation with releases, we can only deploy them on tags.
+#     repo: alanz/vscode-hie-server
+#     branch: master
+#     tags: true
+#     condition: $TRAVIS_OS_NAME = linux
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,65 @@
+language: node_js
+
+node_js:
+- 8
+
+sudo: false
+
+cache:
+  directories:
+    - "node_modules"
+
+os:
+  - osx
+  - linux
+
+# This is needed to enable testing VS Code on Travis, as per
+# https://code.visualstudio.com/docs/extensions/testing-extensions#_running-tests-automatically-on-travis-ci-build-machines
+before_install:
+  - if [ $TRAVIS_OS_NAME == "linux" ]; then
+      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
+      sh -e /etc/init.d/xvfb start;
+      sleep 3;
+    fi
+
+install:
+- npm install
+- npm run vscode:prepublish
+
+script: 
+- npm test --silent
+
+before_deploy:  
+- npm install -g vsce
+- vsce package
+
+# Deploy the extension to the Marketplace and GitHub releases (only on tags).
+# Note that this only deploys from the master branch, but will still allow
+# testing on PRs etc.
+#
+# To setup the deploys:
+#   1) Insert an encrypted GitHub OAuth API key with `travis setup releases`
+#   2) Go to the travis page for the project at, https://travis-ci.org/<User Name>/<Repo Name>
+#      a) Under `More Options` go into `Settings`
+#      b) Set a environment variable `VS_TOKEN` with the value of your VS Code personal token
+#      c) Make sure `Display value in build log` is turned OFF!
+deploy:
+- provider: releases # Deploy the *.vsix pcakge to GitHub releases.
+  file_glob: true
+  file: "*.vsix"
+  skip_cleanup: true
+  on: # Due to a limitation with releases, we can only deploy them on tags.
+    repo: alanz/vscode-hie-server
+    branch: master
+    tags: true
+    condition: $TRAVIS_OS_NAME = linux
+- provider: script # Deploy to VS Code Market Place
+  script: vsce publish -p $VS_TOKEN
+  skip_cleanup: true
+  on: # Publish on all builds on master branch.
+    repo: alanz/vscode-hie-server
+    branch: master
+    condition: $TRAVIS_OS_NAME = linux
+
+notifications:
+  email: false

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,28 +1,28 @@
 // A launch configuration that compiles the extension and then opens it inside a new window
 {
-	"version": "0.1.0",
-	"configurations": [
-		{
-			"name": "Launch Extension",
-			"type": "extensionHost",
-			"request": "launch",
-			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
-			"stopOnEntry": false,
-			"sourceMaps": true,
-			"outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
-			"preLaunchTask": "npm"
-		},
-		{
-			"name": "Launch Tests",
-			"type": "extensionHost",
-			"request": "launch",
-			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
-			"stopOnEntry": false,
-			"sourceMaps": true,
-			"outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],
-			"preLaunchTask": "npm"
-		}
-	]
+    "version": "0.1.0",
+    "configurations": [
+        {
+            "name": "Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
+            "preLaunchTask": "npm: watch"
+        },
+        {
+            "name": "Extension Tests",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],
+            "preLaunchTask": "npm: watch"
+        }
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,9 @@
 // Place your settings in this file to overwrite default and user settings.
 {
     "files.exclude": {
-        "out": false // set this to true to hide the "out" folder with the compiled JS files
+        "out": true, // set this to true to hide the "out" folder with the compiled JS files
+        ".vscode-test": true,
+        "node_modules": true
     },
     "search.exclude": {
         "out": true // set this to false to include "out" folder in search results

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,30 +1,20 @@
-// Available variables which can be used inside of strings.
-// ${workspaceRoot}: the root folder of the team
-// ${file}: the current opened file
-// ${fileBasename}: the current opened file's basename
-// ${fileDirname}: the current opened file's dirname
-// ${fileExtname}: the current opened file's extension
-// ${cwd}: the current working directory of the spawned process
-
-// A task runner that calls a custom npm script that compiles the extension.
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
 {
-    "version": "0.1.0",
-
-    // we want to run npm
-    "command": "npm",
-
-    // the command is a shell script
-    "isShellCommand": true,
-
-    // show the output window only if unrecognized errors occur.
-    "showOutput": "silent",
-
-    // we run the custom script "compile" as defined in package.json
-    "args": ["run", "compile", "--loglevel", "silent"],
-
-    // The tsc compiler is started in watching mode
-    "isWatching": true,
-
-    // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-    "problemMatcher": "$tsc-watch"
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "watch",
+            "problemMatcher": "$tsc-watch",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
 }

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,4 +7,3 @@ src/**
 **/*.map
 .gitignore
 tsconfig.json
-vsc-extension-quickstart.md

--- a/package.json
+++ b/package.json
@@ -155,10 +155,11 @@
         }
     },
     "scripts": {
-        "vscode:prepublish": "tsc -p ./",
-        "compile": "tsc -watch -p ./",
-        "update-vscode": "node ./node_modules/vscode/bin/install",
-        "postinstall": "node ./node_modules/vscode/bin/install"
+        "vscode:prepublish": "npm run compile",
+        "compile": "tsc -p ./",
+        "watch": "tsc -watch -p ./",
+        "postinstall": "node ./node_modules/vscode/bin/install",
+        "test": "npm run compile && node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {
         "@types/mocha": ">=2.2.33",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,14 @@
 {
     "compilerOptions": {
-		    "lib": [ "es2016" ],
         "module": "commonjs",
-		    "moduleResolution": "node",
+        "moduleResolution": "node",
+        "target": "es6",
         "outDir": "out",
+        "lib": [
+            "es2016"
+        ],
         "sourceMap": true,
-        "target": "es6"
+        "rootDir": "."
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
A few last manual steps are needed for the `.travis.yml` file to be done.

1) Insert an encrypted GitHub OAuth API key with `travis setup releases`
2) Enable Travis for alanz/vscode-hie-server
3) Go to the travis page for the project at, https://travis-ci.org/alanz/vscode-hie-server
   a) Under `More Options` go into `Settings`
   b) Set a environment variable `VS_TOKEN` with the value of your VS Code personal token
   c) Make sure `Display value in build log` is turned OFF!

A couple of options for 1., either just comment with the output of the encrypted key here, or somehow allow my user to make releases? Or, we can just forego the process entirely and just keep it on the marketplace itself. 

2) should be straight forward :)

Let me know if there's something missing. Also, while I know we aren't currently utilizing the tests, I thought it made sense just to set them up, so when/if we do they are already running.