### PR TITLE
Fix HIE installation check on Win32 Platforms

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -120,7 +120,7 @@ function activateNoHieCheck(context: ExtensionContext) {
 
 function isHieInstalled(): Promise<boolean> {
   return new Promise((resolve, reject) => {
-    const cmd: string = 'which hie';
+    const cmd: string = ( process.platform === 'win32' ) ? 'where hie' : 'which hie';
     child_process.exec(cmd, (error, stdout, stderr) => resolve(!error));
   });
 }


### PR DESCRIPTION
Closes https://github.com/alanz/vscode-hie-server/issues/34 :Win32 uses `where`