### PR TITLE
Add configuration to use hie-wrapper to launch hie (default: false)

### DIFF
--- a/hie-wrapper.sh
+++ b/hie-wrapper.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+DEBUG=1
+indent=""
+function debug {
+  if [[ $DEBUG == 1 ]]; then
+    echo "$indent$@" >> /tmp/hie-wrapper.log
+  fi
+}
+
+curDir=`pwd`
+debug "Launching HIE for project located at $curDir"
+indent="  "
+
+GHCBIN='ghc'
+# If a .stack-work exists, assume we are using stack.
+if [ -d ".stack-work" ]; then
+  debug "Using stack GHC version"
+  GHCBIN='stack ghc --'
+else
+  debug "Using plain GHC version"
+fi
+versionNumber=`$GHCBIN --version`
+debug $versionNumber
+
+HIEBIN='hie'
+BACKUP_HIEBIN='hie'
+# Match the version number with a HIE version, and provide a fallback without
+# the patch number.
+if [[ $versionNumber = *"8.0.1"* ]]; then
+  debug "Project is using GHC 8.0.1"
+  HIEBIN='hie-8.0.1'
+  BACKUP_HIEBIN='hie-8.0'
+elif [[ $versionNumber = *"8.0.2"* ]]; then
+  debug "Project is using GHC 8.0.2"
+  HIEBIN='hie-8.0.2'
+  BACKUP_HIEBIN='hie-8.0'
+elif [[ $versionNumber = *"8.0"* ]]; then
+  debug "Project is using GHC 8.0.*"
+  HIEBIN='hie-8.0'
+elif [[ $versionNumber = *"8.2.1"* ]]; then
+  debug "Project is using GHC 8.2.1"
+  HIEBIN='hie-8.2.1'
+  BACKUP_HIEBIN='hie-8.2'
+elif [[ $versionNumber = *"8.2.2"* ]]; then
+  debug "Project is using GHC 8.2.2"
+  HIEBIN='hie-8.2.2'
+  BACKUP_HIEBIN='hie-8.2'
+elif [[ $versionNumber = *"8.2"* ]]; then
+  debug "Project is using GHC 8.2.*"
+  HIEBIN='hie-8.2'
+else
+  debug "WARNING: GHC version does not match any of the checked ones."
+fi
+
+if [ -x "$(command -v $HIEBIN)" ]; then
+  debug "$HIEBIN was found on path"
+elif [ -x "$(command -v $BACKUP_HIEBIN)" ]; then
+  debug "Backup $BACKUP_HIEBIN was found on path"
+  HIEBIN=$BACKUP_HIEBIN
+else
+  debug "Falling back to plain hie"
+  HIEBIN='hie'
+fi
+
+debug "Starting HIE"
+
+# Check that HIE is working
+export HIE_SERVER_PATH=`which $HIEBIN`
+
+if [ "X" = "X$HIE_SERVER_PATH" ]; then
+  echo "Content-Length: 100\r\n\r"
+  echo '{"jsonrpc":"2.0","id":1,"error":{"code":-32099,"message":"Cannot find hie in the path"}}'
+  exit 1
+fi
+
+# Run directly
+$HIEBIN --lsp $@
+# $HIEBIN --lsp
+
+# Run with a log
+# $HIEBIN --lsp -d -l /tmp/hie.log $@
+# $HIEBIN --lsp -d -l /tmp/hie.log --ekg $@
+# $HIEBIN --lsp -d -l /tmp/hie.log --vomit $@
+
+# Run with a log and a direct dump of the server output
+# $HIEBIN --lsp -d -l /tmp/hie.log | tee /tmp/hie-wire.log

--- a/package.json
+++ b/package.json
@@ -76,6 +76,11 @@
                     "default": 100,
                     "description": "Controls the maximum number of problems produced by the server."
                 },
+                "languageServerHaskell.useHieWrapper": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Try to automatically select the correct hie version, based on your projects GHC version. NOTE: Build hie using the Makefile to get all versions."
+                },
                 "languageServerHaskell.hlintOn": {
                     "type": "boolean",
                     "default": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,7 +54,11 @@ function activateNoHieCheck(context: ExtensionContext) {
   // context.subscriptions.push(fixer);
   // The server is implemented in node
   // let serverModule = context.asAbsolutePath(path.join('server', 'server.js'));
-  const startupScript = ( process.platform === 'win32' ) ? 'hie-vscode.bat' : 'hie-vscode.sh';
+  let hieLaunchScript = 'hie-vscode.sh';
+  if (workspace.getConfiguration('languageServerHaskell').useHieWrapper) {
+    hieLaunchScript = 'hie-wrapper.sh';
+  }
+  const startupScript = ( process.platform === 'win32' ) ? 'hie-vscode.bat' : hieLaunchScript;
   const serverPath = context.asAbsolutePath(path.join('.', startupScript));
 
   // If the extension is launched in debug mode then the debug server options are used


### PR DESCRIPTION
Following up on https://github.com/haskell/haskell-ide-engine/issues/439.

This adds a hie-wrapper.sh script, which tries to automatically select a hie version that matches the GHC version of the project.

It is enabled by a configuration flag, `useHieWrapper`, which is set to false by default, until we know if it is stable enough to enable by default. It assumes that the user has built different versions of hie and postfixing them with the GHC their are built for (falling back to plain `hie`). I've added a Makefile to make this easy in https://github.com/haskell/haskell-ide-engine/pull/447.

I'm amenable to any changes to the script etc, just let me know if there's something you would prefer instead!

Also, I set `debug=1` for now, so one can `tail -f /tmp/hie-wrapper.log` to see if it works. It'll look something like,

```
Launching HIE for project located at /Users/tehnix/GitHub/Tehnix/STM-Fun
  Using stack GHC version
  The Glorious Glasgow Haskell Compilation System, version 8.0.2
  Project is using GHC 8.0.2
  hie-8.0.2 was found on path
  Starting HIE
```