### PR TITLE
Allow the path to a custom hie wrapper to be specified in settings, fixes #48

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,16 @@
                     "default": false,
                     "description": "Try to automatically select the correct hie version, based on your projects GHC version. NOTE: Build hie using the Makefile to get all versions."
                 },
+                "languageServerHaskell.useCustomHieWrapper": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use your own custom wrapper for hie (remember to specify the path!). This will take effect over useHieWrapper."
+                },
+                "languageServerHaskell.useCustomHieWrapperPath": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Specify the full path to your own custom hie wrapper (e.g. /Users/Alice/.hie-wrapper.sh)."
+                },
                 "languageServerHaskell.hlintOn": {
                     "type": "boolean",
                     "default": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,7 +55,9 @@ function activateNoHieCheck(context: ExtensionContext) {
   // The server is implemented in node
   // let serverModule = context.asAbsolutePath(path.join('server', 'server.js'));
   let hieLaunchScript = 'hie-vscode.sh';
-  if (workspace.getConfiguration('languageServerHaskell').useHieWrapper) {
+  if (workspace.getConfiguration('languageServerHaskell').useCustomHieWrapper) {
+    hieLaunchScript = workspace.getConfiguration('languageServerHaskell').useCustomHieWrapperPath;
+  } else if (workspace.getConfiguration('languageServerHaskell').useHieWrapper) {
     hieLaunchScript = 'hie-wrapper.sh';
   }
   const startupScript = ( process.platform === 'win32' ) ? 'hie-vscode.bat' : hieLaunchScript;


### PR DESCRIPTION
Allow a user to specify the full path to a custom hie wrapper script. The intended use case for this is to allow the user themselves to support workflows that might not be officially supported yet, or simply is necessary because of a differing configuration than the standard.

This would e.g. provide support for nix users to setup their own wrapper script, to get HIE working, as requested in https://github.com/alanz/vscode-hie-server/issues/48.

The PR intentionally does not support `“use hie.sh in a dominating directory”` though, because this can be achieved with a workspace setting in VSCode.