### PR TITLE
Hie custom wrapper support for path variable substitution and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,33 @@ You can disable HLint and also control the maximum number of reported problems,
 "languageServerHaskell.hlintOn": true,
 "languageServerHaskell.maxNumberOfProblems": 100,
 ```
+
+#### HIE Wrapper
+
+Furthermore, the extension supports multiple ways of initializing hie, depending on your needs. The first one is to use the hie-wrapper that follows this extension, and tries to pick the right hie for your GHC version. The following,
+
+```json
+"languageServerHaskell.useHieWrapper": true,
+```
+
+makes VSCode use the `hie-wrapper.sh` file to start hie through. This does assume that you built the hie executable using make build, but will fall back to plain hie.
+
+#### Custom Wrapper
+
+If you need more control, and want to have a custom wrapper, either in your specific project or somewhere else on your computer, you can set a custom wrapper via,
+
+```json
+"languageServerHaskell.useCustomHieWrapper": true,
+"languageServerHaskell.useCustomHieWrapperPath": "~/wrapper-in-home.sh",
+```
+
+There are a few placeholders which will be expanded:
+
+- `~`, `${HOME}` and `${home}` will be expanded into your users' home folder.
+- `${workspaceFolder}` and `${workspaceRoot}` will expand into your current project root.
+
+This can be beneficial if you are using something like nix, to have a wrapper script tailored to your setup.
+
 ## Manual Installation
 Either install the extension via the marketplace (preferred), or if you are testing an unreleased version by,
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,8 +69,10 @@ function activateNoHieCheck(context: ExtensionContext) {
       .replace('${workspaceFolder}', workspaceFolder.uri.path)
       .replace('${workspaceRoot}', workspaceFolder.uri.path)
       .replace('${HOME}', os.homedir)
-      .replace('${home}', os.homedir)
-      .replace('~', os.homedir);
+      .replace('${home}', os.homedir);
+    if (customWrapperPath.startsWith('~')) {
+      customWrapperPath = customWrapperPath.replace('~', os.homedir);
+    }
   }
 
   if (useCustomWrapper) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,10 +69,8 @@ function activateNoHieCheck(context: ExtensionContext) {
       .replace('${workspaceFolder}', workspaceFolder.uri.path)
       .replace('${workspaceRoot}', workspaceFolder.uri.path)
       .replace('${HOME}', os.homedir)
-      .replace('${home}', os.homedir);
-    if (customWrapperPath.startsWith('~')) {
-      customWrapperPath = customWrapperPath.replace('~', os.homedir);
-    }
+      .replace('${home}', os.homedir)
+      .replace(/^~/, os.homedir);
   }
 
   if (useCustomWrapper) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,12 +55,14 @@ function activateNoHieCheck(context: ExtensionContext) {
   // The server is implemented in node
   // let serverModule = context.asAbsolutePath(path.join('server', 'server.js'));
   let hieLaunchScript = 'hie-vscode.sh';
-  if (workspace.getConfiguration('languageServerHaskell').useCustomHieWrapper) {
+  const useCustomWrapper = workspace.getConfiguration('languageServerHaskell').useCustomHieWrapper;
+  if (useCustomWrapper) {
     hieLaunchScript = workspace.getConfiguration('languageServerHaskell').useCustomHieWrapperPath;
   } else if (workspace.getConfiguration('languageServerHaskell').useHieWrapper) {
     hieLaunchScript = 'hie-wrapper.sh';
   }
-  const startupScript = ( process.platform === 'win32' ) ? 'hie-vscode.bat' : hieLaunchScript;
+  // Don't use the .bat launcher, if the user specified a custom wrapper.
+  const startupScript = ( process.platform === 'win32' && !useCustomWrapper ) ? 'hie-vscode.bat' : hieLaunchScript;
   const serverPath = context.asAbsolutePath(path.join('.', startupScript));
 
   // If the extension is launched in debug mode then the debug server options are used


### PR DESCRIPTION
Cleaning up some mistakes in my earlier PR #49 , this PR adds support for the user to be able to substitute `${HOME}`/`${home}`/`~` with the home folder and `${workspaceFolder}`/`${workspaceRoot}` with the project/workspace folder.

Furthermore, since a custom wrapper wouldn't correctly work with a direct `which hie` command, the `isInstalledCheck` is skipped when `useCustomWrapper` is enabled.

Finally, Windows support is added, by adding `!useCustomWrapper` to the windows check for `startupScript`, so it won't switch to the .bat file if `useCustomWrapper` is enabled.

Sorry for the inconvenience in the earlier PR being slightly broken, I've tested this one, and it works. I used the following `custom-wrapper.sh` in both my project folder and home folder,


```bash
# Check that HIE is working
export HIE_SERVER_PATH=`stack exec -- which hie`

if [ "X" = "X$HIE_SERVER_PATH" ]; then
  echo "Content-Length: 100\r\n\r"
  echo '{"jsonrpc":"2.0","id":1,"error":{"code":-32099,"message":"Cannot find hie in the path"}}'
  exit 1
fi

stack exec -- hie --lsp $@
```

Along with the configuration,

```
...
"languageServerHaskell.useCustomHieWrapper": true,
"languageServerHaskell.useCustomHieWrapperPath": "${workspaceFolder}/custom-wrapper.sh"
```