### PR TITLE
Fixed `insertType` command

### DIFF
--- a/src/commands/insertType.ts
+++ b/src/commands/insertType.ts
@@ -14,7 +14,18 @@ export namespace InsertType {
 
   export function registerCommand(client: LanguageClient): Disposable {
     const cmd = commands.registerTextEditorCommand(CommandNames.InsertTypeCommandName, (editor, edit) => {
-      client.sendRequest('workspace/executeCommand', cmd).then(hints => {
+      const ghcCmd = {
+        command: 'ghcmod:type',
+        arguments: [
+          {
+            file: editor.document.uri.toString(),
+            pos: editor.selections[0].active,
+            include_constraints: true,
+          },
+        ],
+      };
+
+      client.sendRequest('workspace/executeCommand', ghcCmd).then(hints => {
         const arr = hints as Array<[Range, string]>;
         if (arr.length === 0) { return; }
         const [rng, typ] = arr[0];


### PR DESCRIPTION
The current `insertType` seems to be broken.
I revert this to the old version.

When I executed InsertType, I got the following error.
Because haskell-lsp got `workspace/executeCommand` with empty params.
```
error log:
[Error - 11:07:30] haskell-lsp:parse error. Object (fromList [("jsonrpc",String "2.0"),("params",Object (fromList [])),("method",String "workspace/executeCommand"),("id",Number 21.0)]) "When parsing the record ExecuteCommandParams of type Language.Haskell.LSP.TH.DataTypesJSON.ExecuteCommandParams the key command was not present." `stack update` and install new haskell-lsp. Or check information on https://marketplace.visualstudio.com/items?itemName=xxxxxxxxxxxxxxx
```
https://github.com/haskell/haskell-ide-engine/issues/468