### PR TITLE
[WIP] Set up HIE to support multi-root workspaces

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,13 @@
+### 0.0.10
+
+Add support for multi-root workspaces, thanks to @tehnix. See the README section
+on [_Using multi-root workspaces_](https://github.com/alanz/vscode-hie-server#using-multi-root-workspaces) for more.
+
+### 0.0.9
+
+Publish to the visual studio marketplace through travis CI via git tags. E.g.
+`git tag -a 0.0.9 -m "Version 0.0.9"` and then `git push origin 0.0.9`.
+
 ### 0.0.8
 
 Add new haskell-ide-engine logo, thanks to @damienflament

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Language server client for haskell using the [HIE](https://github.com/haskell/ha
 - Completion
 - Formatting via [`brittany`](https://github.com/lspitzner/brittany) (`^ ⌥ B` or `Format Document` in command palette)
 - Renaming via [`HaRe`](https://github.com/alanz/HaRe) (`F2` or `Rename Symbol` in command palette)
+- [Multi-root workspace](https://code.visualstudio.com/docs/editor/multi-root-workspaces) support
 
 Additionally the language server itself features,
 - Supports plain GHC projects, cabal projects (sandboxed and non sandboxed) and stack projects
@@ -80,8 +81,29 @@ according to the current version.
 In VS Code, open the extensions tab, and click on the `...` at the top right of it,
 and use the `Install from VSIX...` option to locate and install the generated file.
 
-## Known Issues
-Only works for GHC 8.0.2 projects at the moment.
+## Using multi-root workspaces
+First, check out [what multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces) are. The idea of using multi-root workspaces, is to be able to work on several different Haskell projects, where the GHC version or stackage LTS could differ, and have it work smoothly.
+
+HIE is now started for each workspace folder you have in your multi-root workspace, and several configurations are on a resource (i.e. folder) scope, instead of window (i.e. global) scope.
+
+To showcase the utility of this, let's imagine that we are writing a full-stack Haskell website, and we have three main components:
+
+- a backend using LTS 10.10 and
+- a frontend using GHCJS and LTS 8.11,
+- a common part that is shared between the two, using LTS 8.11.
+
+One way to be able to work on all these in the same VSCode project is to create a new workspace, and then add each folder to the workspace. This way, they are considered separate entities, and HIE will start separately for each.
+
+You can then define how to start HIE for each of these folders, by going into `Settings` and then choosing `Folder Settings -> <the folder you want>`, or just configure the workspace. E.g. the _backend_ and _common_ projects could have a folder settting,
+
+```json
+{
+    "languageServerHaskell.useCustomHieWrapper": true,
+    "languageServerHaskell.useCustomHieWrapperPath": "${workspaceFolder}/hie.sh"
+}
+```
+
+to launch HIE via `hie.sh` inside the backend folder, while the frontend, because of being GHCJS, might not use HIE and use something else instead. This provides a very flexible way of customizing your setup.
 
 ## Release Notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-hie-server",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1987,6 +1987,12 @@
             "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
             "dev": true
         },
+        "prettier": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.11.1.tgz",
+            "integrity": "sha512-T/KD65Ot0PB97xTrG8afQ46x3oiVhnfGjGESSI9NWYcG92+OUPZKkwHqGWXH2t9jK1crnQjubECW0FuOth+hxw==",
+            "dev": true
+        },
         "process-nextick-args": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -2764,31 +2770,31 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz",
-            "integrity": "sha1-hyOdnhZrLXNSJFuKgTWXgEwdY6o="
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.6.0.tgz",
+            "integrity": "sha512-PqHHjuTlz3ks0vyZv3IkdduJReA/lqe6OP5zRl5nXn2ptMLW++fBotNyayyZEQLIF6nNrx/Rn6WhMSHElf02Yw=="
         },
         "vscode-languageclient": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-3.5.0.tgz",
-            "integrity": "sha1-NtAswYaoNlpEZ3GaKQ+yAKmuSQo=",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-4.0.1.tgz",
+            "integrity": "sha512-0fuBZj9pMkeJ8OMyIvSGeRaRVhUaJt+yeFxi7a3sz/AbrngQdcxOovMXPgKuieoBSBKS05gXPS88BsWpJZfBkA==",
             "requires": {
-                "vscode-languageserver-protocol": "3.5.0"
+                "vscode-languageserver-protocol": "3.6.0"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.5.0.tgz",
-            "integrity": "sha1-Bnxcvidwl5U5jRGWksl+u6FFIgk=",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.6.0.tgz",
+            "integrity": "sha512-PN5hVQQQxrtHSZR8UCstqaoI9f2H9JctFTtdIpONWjzQNurWrc48qSXXU/vTfnbSrNou8qrJgkZ4QEZsyozOMA==",
             "requires": {
-                "vscode-jsonrpc": "3.5.0",
-                "vscode-languageserver-types": "3.5.0"
+                "vscode-jsonrpc": "3.6.0",
+                "vscode-languageserver-types": "3.6.1"
             }
         },
         "vscode-languageserver-types": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
-            "integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.6.1.tgz",
+            "integrity": "sha512-Npi3i8gUWcx5h8z5idNqPKBLJmZothXK2FSG4csEmxAR7avb8W6l9Ny+VW9yCUB3bOdD7iXfah8IO0AS1jwQmQ=="
         },
         "wrappy": {
             "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-hie-server",
-    "version": "0.0.7",
+    "version": "0.0.9",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
             "title": "Haskell Language Server",
             "properties": {
                 "languageServerHaskell.maxNumberOfProblems": {
-                    "scope": "window",
+                    "scope": "resource",
                     "type": "number",
                     "default": 100,
                     "description": "Controls the maximum number of problems produced by the server."
@@ -109,7 +109,7 @@
                     "description": "Determines where the type information for selected text will be shown when the `showType` command is triggered (distinct from automatically showing this information when hover is triggered).\ndropdown: in a dropdown\nchannel: will be revealed in an output channel"
                 },
                 "languageServerHaskell.trace.server": {
-                    "scope": "window",
+                    "scope": "resource",
                     "type": "string",
                     "enum": [
                         "off",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-hie-server",
     "displayName": "Haskell Language Server",
     "description": "Language Server Protocol for Haskell via HIE",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "license": "MIT",
     "publisher": "alanz",
     "engines": {
@@ -11,7 +11,8 @@
     "keywords": [
         "language",
         "haskell",
-        "lsp"
+        "lsp",
+        "multi-root ready"
     ],
     "homepage": "https://github.com/alanz/vscode-hie-server",
     "repository": {
@@ -47,16 +48,6 @@
                 ]
             },
             {
-                "id": "cabal",
-                "aliases": [
-                    "cabal",
-                    "Cabal"
-                ],
-                "extensions": [
-                    ".cabal"
-                ]
-            },
-            {
                 "id": "literate haskell",
                 "aliases": [
                     "Literate Haskell",
@@ -78,7 +69,7 @@
                     "description": "Controls the maximum number of problems produced by the server."
                 },
                 "languageServerHaskell.useHieWrapper": {
-                    "scope": "window",
+                    "scope": "resource",
                     "type": "boolean",
                     "default": false,
                     "description": "Try to automatically select the correct hie version, based on your projects GHC version. NOTE: Build hie using the Makefile to get all versions."
@@ -211,6 +202,6 @@
         "justusadam.language-haskell"
     ],
     "dependencies": {
-        "vscode-languageclient": "^3.5.0"
+        "vscode-languageclient": "^4.0.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -72,36 +72,43 @@
             "title": "Haskell Language Server",
             "properties": {
                 "languageServerHaskell.maxNumberOfProblems": {
+                    "scope": "window",
                     "type": "number",
                     "default": 100,
                     "description": "Controls the maximum number of problems produced by the server."
                 },
                 "languageServerHaskell.useHieWrapper": {
+                    "scope": "window",
                     "type": "boolean",
                     "default": false,
                     "description": "Try to automatically select the correct hie version, based on your projects GHC version. NOTE: Build hie using the Makefile to get all versions."
                 },
                 "languageServerHaskell.useCustomHieWrapper": {
+                    "scope": "resource",
                     "type": "boolean",
                     "default": false,
                     "description": "Use your own custom wrapper for hie (remember to specify the path!). This will take effect over useHieWrapper."
                 },
                 "languageServerHaskell.useCustomHieWrapperPath": {
+                    "scope": "resource",
                     "type": "string",
                     "default": "",
                     "description": "Specify the full path to your own custom hie wrapper (e.g. /Users/Alice/.hie-wrapper.sh)."
                 },
                 "languageServerHaskell.hlintOn": {
+                    "scope": "resource",
                     "type": "boolean",
                     "default": true,
                     "description": "Get suggestions from hlint"
                 },
                 "languageServerHaskell.showTypeForSelection.onHover": {
+                    "scope": "resource",
                     "type": "boolean",
                     "default": true,
                     "description": "If true, when an expression is selected, the hover tooltip will attempt to display the type of the entire expression - rather than just the term under the cursor."
                 },
                 "languageServerHaskell.showTypeForSelection.command.location": {
+                    "scope": "resource",
                     "type": "string",
                     "enum": [
                         "dropdown",
@@ -111,6 +118,7 @@
                     "description": "Determines where the type information for selected text will be shown when the `showType` command is triggered (distinct from automatically showing this information when hover is triggered).\ndropdown: in a dropdown\nchannel: will be revealed in an output channel"
                 },
                 "languageServerHaskell.trace.server": {
+                    "scope": "window",
                     "type": "string",
                     "enum": [
                         "off",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,7 +112,7 @@ function activateHieNoCheck(context: ExtensionContext, folder: WorkspaceFolder, 
 
   if (useCustomWrapper) {
     hieLaunchScript = customWrapperPath;
-  } else if (workspace.getConfiguration('languageServerHaskell').useHieWrapper) {
+  } else if (workspace.getConfiguration('languageServerHaskell', uri).useHieWrapper) {
     hieLaunchScript = 'hie-wrapper.sh';
   }
   // Don't use the .bat launcher, if the user specified a custom wrapper.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,8 +13,6 @@ import {
   WorkspaceFolder
 } from 'vscode';
 import {
-  CloseAction,
-  ErrorAction,
   LanguageClient,
   LanguageClientOptions,
   RevealOutputChannelOn,
@@ -34,8 +32,8 @@ const clients: Map<string, LanguageClient> = new Map();
 export async function activate(context: ExtensionContext) {
   // Register HIE to check every time a text document gets opened, to
   // support multi-root workspaces.
-  workspace.onDidOpenTextDocument((document: TextDocument) => activateHie(context, document));
-  workspace.textDocuments.forEach((document: TextDocument) => activateHie(context, document));
+  workspace.onDidOpenTextDocument(async (document: TextDocument) => await activateHie(context, document));
+  workspace.textDocuments.forEach(async (document: TextDocument) => await activateHie(context, document));
   // Stop HIE from any workspace folders that are removed.
   workspace.onDidChangeWorkspaceFolders((event) => {
     for (const folder of event.removed) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,10 +9,15 @@ import * as path from 'path';
 import {
   commands,
   ExtensionContext,
+  TextDocument,
+  Uri,
   window,
-  workspace
+  workspace,
+  WorkspaceFolder
 } from 'vscode';
 import {
+  CloseAction,
+  ErrorAction,
   LanguageClient,
   LanguageClientOptions,
   RevealOutputChannelOn,
@@ -25,9 +30,90 @@ import {
 } from './commands/showType';
 import { DocsBrowser } from './docsBrowser';
 
+let docsBrowserRegistered: boolean = false;
+let hieCommandsRegistered: boolean = false;
+const clients: Map<string, LanguageClient> = new Map();
+
+/*
+ * Sort the workspace folders by length.
+ * Taken from https://github.com/Microsoft/vscode-extension-samples/blob/
+ * 26bc3537d9817d7def2f349ff2a5e0229bbb6b4a/lsp-multi-server-sample/client/src/extension.ts#L14.
+ */
+let sortedWorkspaceFolders: string[];
+function sortWorkspaceFolders(): string[] {
+  if (sortedWorkspaceFolders === void 0) {
+    sortedWorkspaceFolders = workspace.workspaceFolders.map(folder => {
+      let result = folder.uri.toString();
+      if (result.charAt(result.length - 1) !== '/') {
+        result = result + '/';
+      }
+      return result;
+    }).sort((a, b) => a.length - b.length);
+  }
+  return sortedWorkspaceFolders;
+}
+workspace.onDidChangeWorkspaceFolders(() => sortedWorkspaceFolders = undefined);
+
+/*
+ * Extract the outer-most workspace folder.
+ * Taken from https://github.com/Microsoft/vscode-extension-samples/blob/
+ * 26bc3537d9817d7def2f349ff2a5e0229bbb6b4a/lsp-multi-server-sample/client/src/extension.ts#L32.
+ */
+function getOuterMostWorkspaceFolder(folder: WorkspaceFolder): WorkspaceFolder {
+  const sorted = sortWorkspaceFolders();
+  for (const element of sorted) {
+    let uri = folder.uri.toString();
+    if (uri.charAt(uri.length - 1) !== '/') {
+      uri = uri + '/';
+    }
+    if (uri.startsWith(element)) {
+      return workspace.getWorkspaceFolder(Uri.parse(element));
+    }
+  }
+  return folder;
+}
+
 export async function activate(context: ExtensionContext) {
+  // Register HIE to check every time a text document gets opened, to
+  // support multi-root workspaces.
+  workspace.onDidOpenTextDocument((document: TextDocument) => activateHie(context, document));
+  workspace.textDocuments.forEach((document: TextDocument) => activateHie(context, document));
+  workspace.onDidChangeWorkspaceFolders((event) => {
+    for (const folder  of event.removed) {
+      const client = clients.get(folder.uri.toString());
+      if (client) {
+        clients.delete(folder.uri.toString());
+        client.stop();
+      }
+    }
+  });
+}
+
+async function activateHie(context: ExtensionContext, document: TextDocument) {
+  // We are only interested in Haskell files.
+  if ((document.languageId !== 'haskell'
+        && document.languageId !== 'cabal'
+        && document.languageId !== 'literate Haskell')
+        || (document.uri.scheme !== 'file' && document.uri.scheme !== 'untitled')) {
+    return;
+  }
+
+  const uri = document.uri;
+  const folder = workspace.getWorkspaceFolder(uri);
+  // Don't handle files outside of a folder.
+  if (!folder) {
+    return;
+  }
+  // In case we have a nested workspace folder, only start the server on the outer-most.
+  // folder = getOuterMostWorkspaceFolder(folder);
+
+  // If the client already has an LSP server, then don't start a new one.
+  if (clients.has(folder.uri.toString())) {
+    return;
+  }
+
   try {
-    const useCustomWrapper = workspace.getConfiguration('languageServerHaskell').useCustomHieWrapper;
+    const useCustomWrapper = workspace.getConfiguration('languageServerHaskell', uri).useCustomHieWrapper;
     // Check if hie is installed.
     if (!await isHieInstalled() && !useCustomWrapper) {
       // TODO: Once haskell-ide-engine is on hackage/stackage, enable an option to install it via cabal/stack.
@@ -36,38 +122,34 @@ export async function activate(context: ExtensionContext) {
       const forceStart: string = 'Force Start';
       window.showErrorMessage(notInstalledMsg, forceStart).then(option => {
         if (option === forceStart) {
-          activateNoHieCheck(context);
+          activateHieNoCheck(context, folder, uri);
         }
       });
     } else {
-      activateNoHieCheck(context);
+      activateHieNoCheck(context, folder, uri);
     }
   } catch (e) {
     console.error(e);
   }
 }
 
-function activateNoHieCheck(context: ExtensionContext) {
+function activateHieNoCheck(context: ExtensionContext, folder: WorkspaceFolder, uri: Uri) {
+  // Set up the documentation browser.
+  if (!docsBrowserRegistered) {
+    const docsDisposable = DocsBrowser.registerDocsBrowser();
+    context.subscriptions.push(docsDisposable);
+    docsBrowserRegistered = true;
+  }
 
-  const docsDisposable = DocsBrowser.registerDocsBrowser();
-  context.subscriptions.push(docsDisposable);
-
-  // const fixer = languages.registerCodeActionsProvider("haskell", fixProvider);
-  // context.subscriptions.push(fixer);
-  // The server is implemented in node
-  // let serverModule = context.asAbsolutePath(path.join('server', 'server.js'));
   let hieLaunchScript = 'hie-vscode.sh';
+  const useCustomWrapper = workspace.getConfiguration('languageServerHaskell', uri).useCustomHieWrapper;
+  let customWrapperPath = workspace.getConfiguration('languageServerHaskell', uri).useCustomHieWrapperPath;
 
-  const useCustomWrapper = workspace.getConfiguration('languageServerHaskell').useCustomHieWrapper;
-  let customWrapperPath = workspace.getConfiguration('languageServerHaskell').useCustomHieWrapperPath;
-
-  // Substitute variables with their corresponding locations. If the `workspaceFolders` is
-  // undefined, no folders are open.
-  if (useCustomWrapper && workspace.workspaceFolders !== undefined) {
-    const workspaceFolder = workspace.workspaceFolders[0];
+  // Substitute variables with their corresponding locations.
+  if (useCustomWrapper) {
     customWrapperPath = customWrapperPath
-      .replace('${workspaceFolder}', workspaceFolder.uri.path)
-      .replace('${workspaceRoot}', workspaceFolder.uri.path)
+      .replace('${workspaceFolder}', folder.uri.path)
+      .replace('${workspaceRoot}', folder.uri.path)
       .replace('${HOME}', os.homedir)
       .replace('${home}', os.homedir)
       .replace(/^~/, os.homedir);
@@ -82,12 +164,10 @@ function activateNoHieCheck(context: ExtensionContext) {
   const startupScript = ( process.platform === 'win32' && !useCustomWrapper ) ? 'hie-vscode.bat' : hieLaunchScript;
   const serverPath = useCustomWrapper ? startupScript : context.asAbsolutePath(path.join('.', startupScript));
 
-  // If the extension is launched in debug mode then the debug server options are used
-  // Otherwise the run options are used
+  // If the extension is launched in debug mode then the debug server options are used,
+  // otherwise the run options are used
   const tempDir = ( process.platform === 'win32' ) ? '%TEMP%' : '/tmp';
   const serverOptions: ServerOptions = {
-    // run : { module: serverModule, transport: TransportKind.ipc },
-    // debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
     run : { command: serverPath },
     debug: { command: serverPath, args: ['-d', '-l', path.join(tempDir, 'hie.log')] },
   };
@@ -102,6 +182,8 @@ function activateNoHieCheck(context: ExtensionContext) {
       // Notify the server about file changes to '.clientrc files contain in the workspace
       fileEvents: workspace.createFileSystemWatcher('**/.clientrc'),
     },
+    // Set the CWD to the workspace folder
+    workspaceFolder: folder,
     middleware: {
       provideHover: DocsBrowser.hoverLinksMiddlewareHook,
     },
@@ -111,22 +193,34 @@ function activateNoHieCheck(context: ExtensionContext) {
   // Create the language client and start the client.
   const langClient = new LanguageClient('Language Server Haskell', serverOptions, clientOptions);
 
-  context.subscriptions.push(InsertType.registerCommand(langClient));
-
-  ShowTypeCommand.registerCommand(langClient).forEach(x => context.subscriptions.push(x));
-
-  if (workspace.getConfiguration('languageServerHaskell').showTypeForSelection.onHover) {
-    context.subscriptions.push(ShowTypeHover.registerTypeHover(langClient));
+  // Only register the commands once.
+  if (!hieCommandsRegistered) {
+    context.subscriptions.push(InsertType.registerCommand(langClient));
+    ShowTypeCommand.registerCommand(langClient).forEach(x => context.subscriptions.push(x));
+    if (workspace.getConfiguration('languageServerHaskell', uri).showTypeForSelection.onHover) {
+      context.subscriptions.push(ShowTypeHover.registerTypeHover(langClient));
+    }
+    registerHiePointCommand(langClient, 'hie.commands.demoteDef', 'hare:demote', context);
+    registerHiePointCommand(langClient, 'hie.commands.liftOneLevel', 'hare:liftonelevel', context);
+    registerHiePointCommand(langClient, 'hie.commands.liftTopLevel', 'hare:lifttotoplevel', context);
+    registerHiePointCommand(langClient, 'hie.commands.deleteDef', 'hare:deletedef', context);
+    registerHiePointCommand(langClient, 'hie.commands.genApplicative', 'hare:genapplicative', context);
+    hieCommandsRegistered = true;
   }
 
-  registerHiePointCommand(langClient, 'hie.commands.demoteDef', 'hare:demote', context);
-  registerHiePointCommand(langClient, 'hie.commands.liftOneLevel', 'hare:liftonelevel', context);
-  registerHiePointCommand(langClient, 'hie.commands.liftTopLevel', 'hare:lifttotoplevel', context);
-  registerHiePointCommand(langClient, 'hie.commands.deleteDef', 'hare:deletedef', context);
-  registerHiePointCommand(langClient, 'hie.commands.genApplicative', 'hare:genapplicative', context);
-  const disposable = langClient.start();
+  langClient.start();
+  clients.set(folder.uri.toString(), langClient);
+}
 
-  context.subscriptions.push(disposable);
+/*
+ * Deactivate each of the LSP servers..
+ */
+export function deactivate(): Thenable<void> {
+  const promises: Array<Thenable<void>> = [];
+  for (const client of clients.values()) {
+    promises.push(client.stop());
+  }
+  return Promise.all(promises).then(() => undefined);
 }
 
 async function isHieInstalled(): Promise<boolean> {


### PR DESCRIPTION
Preliminary support for multi-root workspaces. The idea is to launch a HIE server for each folder in the workspace, since they could vary in GHC versions etc.

Additionally, this also sets the scopes on various configs to be either window (global/workspace configurable) or resource (folder in multi-root workspace configurable), e.g. supporting custom hie wrappers and some options per folder basis in the multi-root workspace.

My ultimate goal with this is to provide some nicer support for working in a shared code setup with backend, common, frontend (currently testing with [this Miso setup](https://github.com/Tehnix/miso-isomorphic-stack)).

There are some kinks here and there. If you want to help test it, you can set up a workspace in VS Code by either
- right click in the file tree/sidebar and choose `Add Folder to Workspace...` and add a new Haskell source folder, or
- opening a new blank window, and doing the above, for a fresh setup.

Inspiration is taken from the [LSP multi server (one server per root) example](https://github.com/Microsoft/vscode-extension-samples/blob/master/lsp-multi-server-sample/client/src/extension.ts).