### PR TITLE
Fix documentation under newer VSCode lang server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
             "dev": true
         },
         "array-differ": {
@@ -322,7 +322,7 @@
         "color-convert": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
             "dev": true,
             "requires": {
                 "color-name": "1.1.3"
@@ -337,7 +337,7 @@
         "color-support": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+            "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI=",
             "dev": true
         },
         "combined-stream": {
@@ -408,7 +408,7 @@
         "debug": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
             "dev": true,
             "requires": {
                 "ms": "2.0.0"
@@ -516,7 +516,7 @@
         "esprima": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-            "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+            "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
             "dev": true
         },
         "esutils": {
@@ -744,7 +744,7 @@
         "glob": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
             "dev": true,
             "requires": {
                 "fs.realpath": "1.0.0",
@@ -884,7 +884,7 @@
         "growl": {
             "version": "1.10.3",
             "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-            "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+            "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
             "dev": true
         },
         "gulp-chmod": {
@@ -1163,7 +1163,7 @@
                 "queue": {
                     "version": "4.4.2",
                     "resolved": "https://registry.npmjs.org/queue/-/queue-4.4.2.tgz",
-                    "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
+                    "integrity": "sha1-Wpcz2ai4vRs26TS8nFWribKOKcc=",
                     "dev": true,
                     "requires": {
                         "inherits": "2.0.3"
@@ -1317,7 +1317,7 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
             "dev": true
         },
         "is-dotfile": {
@@ -1742,7 +1742,7 @@
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
             "dev": true,
             "requires": {
                 "brace-expansion": "1.1.8"
@@ -2023,7 +2023,7 @@
         "randomatic": {
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-            "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+            "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
             "dev": true,
             "requires": {
                 "is-number": "3.0.0",
@@ -2079,7 +2079,7 @@
         "regex-cache": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+            "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
             "dev": true,
             "requires": {
                 "is-equal-shallow": "0.1.3"
@@ -2280,7 +2280,7 @@
         "rimraf": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
             "dev": true,
             "requires": {
                 "glob": "7.1.2"
@@ -2289,7 +2289,7 @@
         "safe-buffer": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+            "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
             "dev": true
         },
         "semver": {
@@ -2310,7 +2310,7 @@
         "source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
             "dev": true
         },
         "source-map-support": {
@@ -2391,7 +2391,7 @@
         "streamfilter": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.7.tgz",
-            "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
+            "integrity": "sha1-rj5kUiqlo1wGH9F/Z2IMdlPGQ8k=",
             "dev": true,
             "requires": {
                 "readable-stream": "2.3.3"
@@ -2764,31 +2764,31 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz",
-            "integrity": "sha1-hyOdnhZrLXNSJFuKgTWXgEwdY6o="
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.6.1.tgz",
+            "integrity": "sha512-+Eb+Dxf2kC2h079msx61hkblxAKE0S2j78+8QpnigLAO2aIIjkCwTIH34etBrU8E8VItRinec7YEwULx9at5bQ=="
         },
         "vscode-languageclient": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-3.5.1.tgz",
-            "integrity": "sha512-GTQ+hSq/o4c/y6GYmyP9XNrVoIu0NFZ67KltSkqN+tO0eUNDIlrVNX+3DJzzyLhSsrctuGzuYWm3t87mNAcBmQ==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-4.1.3.tgz",
+            "integrity": "sha512-3tu79B56apocobPGkHm7YWobjhNKCU7H4cUk+rkVFCNoOSAm2wZlN2J6HdC15/ONALY4ai25BeyQ+aQaFmM1Jg==",
             "requires": {
-                "vscode-languageserver-protocol": "3.5.1"
+                "vscode-languageserver-protocol": "3.7.1"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.5.1.tgz",
-            "integrity": "sha512-1fPDIwsAv1difCV+8daOrJEGunClNJWqnUHq/ncWrjhitKWXgGmRCjlwZ3gDUTt54yRcvXz1PXJDaRNvNH6pYA==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.7.1.tgz",
+            "integrity": "sha512-AKX9XQ49m/lpiDLZJBypFNc5eAXNlSecunYU5m4o5WIwGgW86TWnXVdziuFm47W2SdigDa/jVbxLPSNUeut9fQ==",
             "requires": {
-                "vscode-jsonrpc": "3.5.0",
-                "vscode-languageserver-types": "3.5.0"
+                "vscode-jsonrpc": "3.6.1",
+                "vscode-languageserver-types": "3.7.1"
             }
         },
         "vscode-languageserver-types": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
-            "integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.7.1.tgz",
+            "integrity": "sha512-ftGfU79AnnI3OHCG7kzCCN47jNI7BjECPAH2yhddtYTiQk0bnFbuFeQKvpXQcyNI3GsKEx5b6kSiBYshTiep6w=="
         },
         "wrappy": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "publisher": "alanz",
     "engines": {
-        "vscode": "^1.18.0"
+        "vscode": "^1.22.0"
     },
     "keywords": [
         "language",
@@ -217,6 +217,6 @@
         "justusadam.language-haskell"
     ],
     "dependencies": {
-        "vscode-languageclient": "^3.5.0"
+        "vscode-languageclient": "^4.1.3"
     }
 }

--- a/src/docsBrowser.ts
+++ b/src/docsBrowser.ts
@@ -72,6 +72,11 @@ export namespace DocsBrowser {
             const mstr = new MarkdownString(transform(ms));
             mstr.isTrusted = true;
             return mstr;
+        }
+        else if (typeof ms === 'object') {
+            const mstr = new MarkdownString(transform(ms.value));
+            mstr.isTrusted = true;
+            return mstr;
         } else {
             return ms;
         }

--- a/src/docsBrowser.ts
+++ b/src/docsBrowser.ts
@@ -72,8 +72,7 @@ export namespace DocsBrowser {
             const mstr = new MarkdownString(transform(ms));
             mstr.isTrusted = true;
             return mstr;
-        }
-        else if (typeof ms === 'object') {
+        } else if (typeof ms === 'object') {
             const mstr = new MarkdownString(transform(ms.value));
             mstr.isTrusted = true;
             return mstr;


### PR DESCRIPTION
##  Changes
- Fix `Documentation` link for newer VSCode

**Note:** As @halhenke suggested, we should be looking for https://code.visualstudio.com/updates/v1_21#_webview-api for the future versions of this functionality