### PR TITLE
Add command for case splitting

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,11 @@
         "command": "hie.commands.showType",
         "title": "Haskell: Show type",
         "description": "Show type for the expression"
+      },
+      {
+        "command": "hie.commands.caseSplit",
+        "title": "Haskell: Split case",
+        "description": "Generate pattern matches for the identifier under the cursor"
       }
     ],
     "keybindings": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -203,6 +203,7 @@ function activateHieNoCheck(context: ExtensionContext, folder: WorkspaceFolder, 
     registerHiePointCommand('hie.commands.liftTopLevel', 'hare:lifttotoplevel', context);
     registerHiePointCommand('hie.commands.deleteDef', 'hare:deletedef', context);
     registerHiePointCommand('hie.commands.genApplicative', 'hare:genapplicative', context);
+    registerHiePointCommand('hie.commands.caseSplit', 'ghcmod:casesplit', context);
     hieCommandsRegistered = true;
   }
 


### PR DESCRIPTION
This PR accompanies haskell/haskell-ide-engine#530.

Example:
```haskell
f :: Either Int String -> [Char]
f e = "Hello World"
```

put your cursor in front of the `e` identifier and run `Haskell: Split case`.
The result should be:
```haskell
f :: Either Int String -> [Char]
f (Left e) = "Hello World"
f (Right e) = "Hello World"
```

It works as long as the cursor is on the identifier that you wish to generate pattern matches for.
Let me know what you think!