### PR TITLE
Use the exe hie-wrapper from haskell-ide-engine

### DIFF
--- a/hie-vscode.bat
+++ b/hie-vscode.bat
@@ -3,11 +3,16 @@
 set HIE_SERVER_PATH=
 for /f "delims=" %%p in ('where hie') do set HIE_SERVER_PATH=%%p
 
-if [%HIE_SERVER_PATH%] == [] (
+set HIE_WRAPPER_PATH=
+for /f "delims=" %%p in ('where hie-wrapper') do set HIE_WRAPPER_PATH=%%p
+
+rem Need to check that neither is found
+if [%HIE_WRAPPER_PATH%] == [] (
   echo Content-Length: 100
   echo:
   echo {"jsonrpc":"2.0","id":1,"error":{"code":-32099,"message":"Cannot find hie.exe in the path"}}
   exit 1
 )
 
-hie --lsp %1 %2 %3 %4 %5 %6 %7 %8 %9
+rem Need to run hie-wrapper if found, else hie
+hie-wrapper --lsp %1 %2 %3 %4 %5 %6 %7 %8 %9

--- a/hie-vscode.sh
+++ b/hie-vscode.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 
 export HIE_SERVER_PATH=`which hie`
+export HIE_WRAPPER_PATH=`which hie-wrapper`
 
-if [ "X" = "X$HIE_SERVER_PATH" ]; then
+if [ "X" = "X$HIE_WRAPPER_PATH" ]; then
+hie-wrapper --lsp $@
+elif [ "X" = "X$HIE_SERVER_PATH" ]; then
   echo "Content-Length: 100\r\n\r"
   echo '{"jsonrpc":"2.0","id":1,"error":{"code":-32099,"message":"Cannot find hie.exe in the path"}}'
   exit 1

--- a/hie-wrapper-old.sh
+++ b/hie-wrapper-old.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+DEBUG=1
+indent=""
+function debug {
+  if [[ $DEBUG == 1 ]]; then
+    echo "$indent$@" >> /tmp/hie-wrapper.log
+  fi
+}
+
+curDir=`pwd`
+debug "Launching HIE for project located at $curDir"
+indent="  "
+
+GHCBIN='ghc'
+# If a .stack-work exists, assume we are using stack.
+if [ -d ".stack-work" ]; then
+  debug "Using stack GHC version"
+  GHCBIN='stack ghc --'
+else
+  debug "Using plain GHC version"
+fi
+versionNumber=`$GHCBIN --version`
+debug $versionNumber
+
+HIEBIN='hie'
+BACKUP_HIEBIN='hie'
+# Match the version number with a HIE version, and provide a fallback without
+# the patch number.
+
+# GHC 8.0.*
+if [[ $versionNumber = *"8.0.1"* ]]; then
+  debug "Project is using GHC 8.0.1"
+  HIEBIN='hie-8.0.1'
+  BACKUP_HIEBIN='hie-8.0'
+elif [[ $versionNumber = *"8.0.2"* ]]; then
+  debug "Project is using GHC 8.0.2"
+  HIEBIN='hie-8.0.2'
+  BACKUP_HIEBIN='hie-8.0'
+elif [[ $versionNumber = *"8.0"* ]]; then
+  debug "Project is using GHC 8.0.*"
+  HIEBIN='hie-8.0'
+
+# GHC 8.2.*
+elif [[ $versionNumber = *"8.2.1"* ]]; then
+  debug "Project is using GHC 8.2.1"
+  HIEBIN='hie-8.2.1'
+  BACKUP_HIEBIN='hie-8.2'
+elif [[ $versionNumber = *"8.2.2"* ]]; then
+  debug "Project is using GHC 8.2.2"
+  HIEBIN='hie-8.2.2'
+  BACKUP_HIEBIN='hie-8.2'
+elif [[ $versionNumber = *"8.2"* ]]; then
+  debug "Project is using GHC 8.2.*"
+  HIEBIN='hie-8.2'
+
+# GHC 8.4.*
+elif [[ $versionNumber = *"8.4.3"* ]]; then
+  debug "Project is using GHC 8.4.3"
+  HIEBIN='hie-8.4.3'
+  BACKUP_HIEBIN='hie-8.4'
+elif [[ $versionNumber = *"8.4.2"* ]]; then
+  debug "Project is using GHC 8.4.2"
+  HIEBIN='hie-8.4.2'
+  BACKUP_HIEBIN='hie-8.4'
+elif [[ $versionNumber = *"8.4"* ]]; then
+  debug "Project is using GHC 8.4.*"
+  HIEBIN='hie-8.4'
+
+else
+  debug "WARNING: GHC version does not match any of the checked ones."
+fi
+
+if [ -x "$(command -v $HIEBIN)" ]; then
+  debug "$HIEBIN was found on path"
+elif [ -x "$(command -v $BACKUP_HIEBIN)" ]; then
+  debug "Backup $BACKUP_HIEBIN was found on path"
+  HIEBIN=$BACKUP_HIEBIN
+else
+  debug "Falling back to plain hie"
+  HIEBIN='hie'
+fi
+
+debug "Starting HIE"
+
+# Check that HIE is working
+export HIE_SERVER_PATH=`which $HIEBIN`
+
+if [ "X" = "X$HIE_SERVER_PATH" ]; then
+  echo "Content-Length: 100\r\n\r"
+  echo '{"jsonrpc":"2.0","id":1,"error":{"code":-32099,"message":"Cannot find hie in the path"}}'
+  exit 1
+fi
+
+# Run directly
+$HIEBIN --lsp $@
+# $HIEBIN --lsp
+
+# Run with a log
+# $HIEBIN --lsp -d -l /tmp/hie.log $@
+# $HIEBIN --lsp -d -l /tmp/hie.log --ekg $@
+# $HIEBIN --lsp -d -l /tmp/hie.log --vomit $@
+
+# Run with a log and a direct dump of the server output
+# $HIEBIN --lsp -d -l /tmp/hie.log | tee /tmp/hie-wire.log

--- a/hie-wrapper.sh
+++ b/hie-wrapper.sh
@@ -11,75 +11,8 @@ curDir=`pwd`
 debug "Launching HIE for project located at $curDir"
 indent="  "
 
-GHCBIN='ghc'
-# If a .stack-work exists, assume we are using stack.
-if [ -d ".stack-work" ]; then
-  debug "Using stack GHC version"
-  GHCBIN='stack ghc --'
-else
-  debug "Using plain GHC version"
-fi
-versionNumber=`$GHCBIN --version`
-debug $versionNumber
 
-HIEBIN='hie'
-BACKUP_HIEBIN='hie'
-# Match the version number with a HIE version, and provide a fallback without
-# the patch number.
-
-# GHC 8.0.*
-if [[ $versionNumber = *"8.0.1"* ]]; then
-  debug "Project is using GHC 8.0.1"
-  HIEBIN='hie-8.0.1'
-  BACKUP_HIEBIN='hie-8.0'
-elif [[ $versionNumber = *"8.0.2"* ]]; then
-  debug "Project is using GHC 8.0.2"
-  HIEBIN='hie-8.0.2'
-  BACKUP_HIEBIN='hie-8.0'
-elif [[ $versionNumber = *"8.0"* ]]; then
-  debug "Project is using GHC 8.0.*"
-  HIEBIN='hie-8.0'
-
-# GHC 8.2.*
-elif [[ $versionNumber = *"8.2.1"* ]]; then
-  debug "Project is using GHC 8.2.1"
-  HIEBIN='hie-8.2.1'
-  BACKUP_HIEBIN='hie-8.2'
-elif [[ $versionNumber = *"8.2.2"* ]]; then
-  debug "Project is using GHC 8.2.2"
-  HIEBIN='hie-8.2.2'
-  BACKUP_HIEBIN='hie-8.2'
-elif [[ $versionNumber = *"8.2"* ]]; then
-  debug "Project is using GHC 8.2.*"
-  HIEBIN='hie-8.2'
-
-# GHC 8.4.*
-elif [[ $versionNumber = *"8.4.3"* ]]; then
-  debug "Project is using GHC 8.4.3"
-  HIEBIN='hie-8.4.3'
-  BACKUP_HIEBIN='hie-8.4'
-elif [[ $versionNumber = *"8.4.2"* ]]; then
-  debug "Project is using GHC 8.4.2"
-  HIEBIN='hie-8.4.2'
-  BACKUP_HIEBIN='hie-8.4'
-elif [[ $versionNumber = *"8.4"* ]]; then
-  debug "Project is using GHC 8.4.*"
-  HIEBIN='hie-8.4'
-
-else
-  debug "WARNING: GHC version does not match any of the checked ones."
-fi
-
-if [ -x "$(command -v $HIEBIN)" ]; then
-  debug "$HIEBIN was found on path"
-elif [ -x "$(command -v $BACKUP_HIEBIN)" ]; then
-  debug "Backup $BACKUP_HIEBIN was found on path"
-  HIEBIN=$BACKUP_HIEBIN
-else
-  debug "Falling back to plain hie"
-  HIEBIN='hie'
-fi
-
+HIEBIN='hie-wrapper'
 debug "Starting HIE"
 
 # Check that HIE is working


### PR DESCRIPTION
Instead of trying to choose the right version in our own wrapper.

This needs to be updated/checked for windows and mac.

Help please.