### PR TITLE
Update installation instructions to match haskell-ide-engine instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The language client requires you to manually install the [HIE](https://github.co
 
 ```bash
 $ git clone https://github.com/haskell/haskell-ide-engine --recursive
-$ cd haskell-ide-engine && make build
+$ cd haskell-ide-engine && make build-all
 ```
 
 Alternatively you can just `stack install`, but `make build` will give you the best setup.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ git clone https://github.com/haskell/haskell-ide-engine --recursive
 $ cd haskell-ide-engine && make build-all
 ```
 
-Alternatively you can just `stack install`, but `make build` will give you the best setup.
+Alternatively you can just `stack install`, but `make build-all` will give you the best setup.
 
 ## Features
 


### PR DESCRIPTION
I've updated the readme to reflect the [currently recommended](https://github.com/haskell/haskell-ide-engine#installation-with-stack) way of installing hie.