### PR TITLE
Update vscode-languageclient to 4.4.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+### 0.0.21
+
+* Update the vscode-languageclient to v4.4.0
+
 ### 0.0.20
 
 * Add the case-split function (@txsmith). Required hie >= 0.2.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-hie-server",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2752,9 +2752,9 @@
       }
     },
     "url-parse": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
-      "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
       "dev": true,
       "requires": {
         "querystringify": "^2.0.0",
@@ -2885,27 +2885,27 @@
       "integrity": "sha512-T24Jb5V48e4VgYliUXMnZ379ItbrXgOimweKaJshD84z+8q7ZOZjJan0MeDe+Ugb+uqERDVV8SBmemaGMSMugA=="
     },
     "vscode-languageclient": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-4.2.1.tgz",
-      "integrity": "sha512-zeixIe2MiKPHiSNjEUmRhWFiNCGUwUNvefBiA9diZc7fXE8DX+AhfwpsOLYauO8Q8C6gW8f9OQvy3Vn2hBvY4g==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-4.4.0.tgz",
+      "integrity": "sha512-sXBwIcwG4W5MjnDAfXf0hM5ErOcXxEBlix6QJb5ijf0gtecYygrMAqv8hag7sEg/jCCOKQdXJ4K1iZL3GZcJZg==",
       "requires": {
-        "vscode-languageserver-protocol": "^3.8.1"
+        "vscode-languageserver-protocol": "^3.10.0"
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.8.1",
+      "version": "3.10.0",
       "resolved":
-        "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.8.1.tgz",
-      "integrity": "sha512-KdeetvQ2JavRiuE9afNrV5+xJZocj7NGPQwH4kpSFw5cp+0wijv87qgXfSEvmwPUaknhMBoSuSrSIG/LRrzWJQ==",
+        "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.10.0.tgz",
+      "integrity": "sha512-PNNmKM0IcQPRiY1oUIxfwseBvxS5Sa5aZUpTcq/qsXWclnl8FFNs8oCCoAtyLhBXnuJvybWUNafiA78y0unJDA==",
       "requires": {
         "vscode-jsonrpc": "^3.6.2",
-        "vscode-languageserver-types": "^3.8.1"
+        "vscode-languageserver-types": "^3.10.0"
       }
     },
     "vscode-languageserver-types": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.8.2.tgz",
-      "integrity": "sha512-2RMkyt1O1czGPCnkjKZWSio2D8oh3XlQ4zi4W2xL8q2Dvi4hB3/DEt+wYyzo4hmE2ZFP0RB8PXyzHyed7p1hbw=="
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.10.0.tgz",
+      "integrity": "sha512-vxmCsVZGwq8X40SuLP8Ix7V0rq5V/7iQUjRVe2Oxm+TbmjxtjK4dpHHXQCUawjA4fhPA9FwjSRbDhbvQmYCfMw=="
     },
     "which": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "publisher": "alanz",
   "engines": {
-    "vscode": "^1.22.0"
+    "vscode": "^1.25.0"
   },
   "keywords": ["language", "haskell", "lsp", "multi-root ready"],
   "homepage": "https://github.com/alanz/vscode-hie-server",
@@ -218,6 +218,6 @@
     "lru-cache": "^4.1.3",
     "request": "^2.86.0",
     "request-promise-native": "^1.0.5",
-    "vscode-languageclient": "^4.2.0"
+    "vscode-languageclient": "^4.4.0"
   }
 }


### PR DESCRIPTION
Requires vscode 1.25, provides hierarchical document symbol support