### PR TITLE
Fix hie-vscode script to use hie-wrapper if available

### DIFF
--- a/hie-vscode.sh
+++ b/hie-vscode.sh
@@ -3,7 +3,7 @@
 export HIE_SERVER_PATH=`which hie`
 export HIE_WRAPPER_PATH=`which hie-wrapper`
 
-if [ "X" = "X$HIE_WRAPPER_PATH" ]; then
+if [ ! "X" = "X$HIE_WRAPPER_PATH" ]; then
 hie-wrapper --lsp $@
 elif [ "X" = "X$HIE_SERVER_PATH" ]; then
   echo "Content-Length: 100\r\n\r"


### PR DESCRIPTION
- I was getting the error "mismatch GHC version, maybe use hie-wrapper" in VSCode
- I checked `ps aux | grep hie` and saw that `hie` was launched by `hie-vscode.sh` (instead of `hie-wrapper`)
- Updating the bash script with this fix, I relaunched VSCode and `ps aux | grep hie` showed that `hie-vscode.sh` had now launched `hie-wrapper` and `hie-8.2.2`
- Note: I'm not sure if the windows `.bat` script is also broken?