### PR TITLE
Bugfix for stack version on Windows

### DIFF
--- a/hie-vscode.bat
+++ b/hie-vscode.bat
@@ -14,5 +14,8 @@ if [%HIE_WRAPPER_PATH%] == [] (
   exit 1
 )
 
+rem Fix for access violations: https://github.com/commercialhaskell/stack/issues/3765#issuecomment-436407467
+set __COMPAT_LAYER=
+
 rem Need to run hie-wrapper if found, else hie
 hie-wrapper --lsp %1 %2 %3 %4 %5 %6 %7 %8 %9


### PR DESCRIPTION
Bugfix for: https://github.com/alanz/vscode-hie-server/issues/135

Clears the `__COMPAT_LAYER` variable before running the wrapper so that the ```stack ghc -- --numeric-version``` command doesn't fail and cause fallback behavior. 

Original thread for access violations: https://github.com/commercialhaskell/stack/issues/3765