### PR TITLE
Enable find widget for doc/source view

### DIFF
--- a/src/docsBrowser.ts
+++ b/src/docsBrowser.ts
@@ -28,7 +28,8 @@ export namespace DocsBrowser {
       let panel;
       try {
         panel = window.createWebviewPanel('haskell.showDocumentationPanel', ttl, ViewColumn.Two, {
-          localResourceRoots: [Uri.file(documentationDirectory)]
+          localResourceRoots: [Uri.file(documentationDirectory)],
+          enableFindWidget: true
         });
 
         // tslint:disable-next-line:max-line-length


### PR DESCRIPTION
I remember being able to search the documentation/source window before vscode deprecated previewHtml. This commit is to bring back that functionality.