### PR TITLE
Fix hie being run if hie-wrapper crashes

### DIFF
--- a/hie-vscode.sh
+++ b/hie-vscode.sh
@@ -4,16 +4,15 @@ export HIE_SERVER_PATH=`which hie`
 export HIE_WRAPPER_PATH=`which hie-wrapper`
 
 if [ ! "X" = "X$HIE_WRAPPER_PATH" ]; then
-hie-wrapper $@
+  hie-wrapper $@
 elif [ "X" = "X$HIE_SERVER_PATH" ]; then
   echo "Content-Length: 100\r\n\r"
   echo '{"jsonrpc":"2.0","id":1,"error":{"code":-32099,"message":"Cannot find hie.exe in the path"}}'
   exit 1
+else
+  # Run directly
+  hie $@
 fi
-
-# Run directly
-hie $@
-#hie --lsp
 
 # Run with a log
 # hie --lsp -d -l /tmp/hie.log $@


### PR DESCRIPTION
If `hie-wrapper` bombed, the script would run on down to invoke `hie` a second time