### PR TITLE
Expose diagnosticsOnChange option

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,13 @@
           "default": 100,
           "description": "Controls the maximum number of problems produced by the server."
         },
+        "languageServerHaskell.diagnosticsOnChange": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "description":
+            "Compute diagnostics continuously as you type. Turn off to only generate diagnostics on file save."
+        },
         "languageServerHaskell.liquidOn": {
           "scope": "resource",
           "type": "boolean",


### PR DESCRIPTION
Adds the option to package.yaml so that it shows up in VSCode's
settings.

Fixes #39 