### PR TITLE
Update HIE install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,14 @@ The language client requires you to manually install the [HIE](https://github.co
 
 ```bash
 $ git clone https://github.com/haskell/haskell-ide-engine --recursive
-$ cd haskell-ide-engine && ./install.hs build-all
+$ cd haskell-ide-engine && ./install.hs build
+```
+
+On Windows, it is advised to either install HIE at the root of the drive, and/or to enable [Win32 Long paths](https://github.com/haskell/haskell-ide-engine#windows-specific-pre-requirements).
+
+```cmd
+C:\> git clone https://github.com/haskell/haskell-ide-engine --recursive hie
+C:\> cd hie && stack ./install.hs build
 ```
 
 If you experience difficulties, use the instructions at https://github.com/haskell/haskell-ide-engine#installation


### PR DESCRIPTION
Recommend `./install.hs build` instead of the now removed `./install.hs build-all`.

Add section on installing on Windows.

Closes #175 