### PR TITLE
Introduce noLspParam flag to config

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+### 0.0.33
+
+* Introduced configuration setting `noLspParam`, default `false` to control
+  setting the `--lsp` flag for the hie server. So by default we will set the
+  command line argument for the server, but it can be turned off.
+
 ### 0.0.32
 
 * Re-enable the `--lsp` flag for the hie server

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-hie-server",
   "displayName": "Haskell Language Server",
   "description": "Language Server Protocol for Haskell via HIE",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "license": "MIT",
   "publisher": "alanz",
   "engines": {
@@ -108,6 +108,12 @@
           "default": "",
           "description":
             "Specify the full path to your own custom hie wrapper (e.g. ${HOME}/.hie-wrapper.sh). Works with ~, ${HOME} and ${workspaceFolder}."
+        },
+        "languageServerHaskell.noLspParam": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "description": "Do not set the '--lsp' flag in the hie/hie-wrapper arguments when launching it"
         },
         "languageServerHaskell.showTypeForSelection.onHover": {
           "scope": "resource",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,6 +106,7 @@ function activateHieNoCheck(context: ExtensionContext, folder: WorkspaceFolder, 
   const useCustomWrapper = workspace.getConfiguration('languageServerHaskell', uri).useCustomHieWrapper;
   let hieExecutablePath = workspace.getConfiguration('languageServerHaskell', uri).hieExecutablePath;
   let customWrapperPath = workspace.getConfiguration('languageServerHaskell', uri).useCustomHieWrapperPath;
+  const noLspParam = workspace.getConfiguration('languageServerHaskell', uri).noLspParam;
   const logLevel = workspace.getConfiguration('languageServerHaskell', uri).trace.server;
   const logFile = workspace.getConfiguration('languageServerHaskell', uri).logFile;
 
@@ -148,7 +149,7 @@ function activateHieNoCheck(context: ExtensionContext, folder: WorkspaceFolder, 
   } else if (logLevel === 'messages') {
     debugArgs = ['-d'];
   }
-  if (!useCustomWrapper) {
+  if (!noLspParam) {
     runArgs.unshift('--lsp');
     debugArgs.unshift('--lsp');
   }


### PR DESCRIPTION
If this flag is set to true, we will not add the `--lsp` flag when
launching hie/hie-wrapper.

Should alleviate #186, #185, #187 