### PR TITLE
Added ormolu as a formatting provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
         "languageServerHaskell.formattingProvider": {
           "scope": "resource",
           "type": "string",
-          "enum": ["brittany", "floskell", "none"],
+          "enum": ["brittany", "floskell", "ormolu", "none"],
           "default": "brittany",
           "description": "The tool to use for formatting requests."
         },


### PR DESCRIPTION
Hi! This should complement https://github.com/haskell/haskell-ide-engine/pull/1481. Is there anything else to be done for the VSCode extension to recognise and operate with the formatter on HIE?