### PR TITLE
Add Nix expression to build and run webpack

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,18 @@
+{ pkgs ? import <nixpkgs> {} }:
+with pkgs;
+pkgs.mkYarnPackage {
+  name = "vscode-hie-server";
+  src = ./.;
+  packageJSON = ./package.json;
+  yarnLock = ./yarn.lock;
+
+  installPhase = ''
+    mkdir -p "$out/dist"
+    yarn vscode:prepublish --output-path "$out/dist"
+    mv deps/vscode-hie-server/{package.json,hie-vscode.sh,hie-vscode.bat} "$out"
+  '';
+
+  distPhase = ''
+    true
+  '';
+}


### PR DESCRIPTION
After generating yarn.lock, simply run `nix-build` to create a
derivation containg the webpacked plugin, package.json and the
hie-vscode wrappers.