### PR TITLE
Corrects old command names in `package.json` (fixes #243)

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,12 +161,12 @@
     },
     "commands": [
       {
-        "command": "hie.commands.importIdentifier",
+        "command": "haskell.commands.importIdentifier",
         "title": "Haskell: Import identifier",
         "description": "Imports a function or type based on a Hoogle search"
       },
       {
-        "command": "hie.commands.restartHie",
+        "command": "haskell.commands.restartServer",
         "title": "Haskell: Restart Haskell LSP server",
         "description": "Restart the Haskell LSP server"
       }


### PR DESCRIPTION
In `package.json`, some commands aren't updated accordingly to the recent command name change, resulting in #243 
This pull request just fixes those errors and revives `Restart Server` and `Import identifier` features.

Fixes #243.