### PR TITLE
Add "ignore standalone" option that disables HLS for files that don't belong to any folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,12 @@
           "default": "",
           "description": "Manually set a language server executable. Can be something on the $PATH or a path to an executable itself. Works with ~, ${HOME} and ${workspaceFolder}."
         },
+        "haskell.ignoreStandalone": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "description": "Don't spawn language servers for stand-alone files (i.e. files that don't belong to any folder)"
+        },
         "haskell.updateBehavior": {
           "scope": "machine",
           "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,8 +133,9 @@ async function activeServer(context: ExtensionContext, document: TextDocument) {
 }
 
 async function activateServerForFolder(context: ExtensionContext, uri: Uri, folder?: WorkspaceFolder) {
+  const ignoreStandalone = workspace.getConfiguration('haskell').ignoreStandalone;
   const clientsKey = folder ? folder.uri.toString() : uri.toString();
-
+  if (!folder && ignoreStandalone) return;
   // If the client already has an LSP server for this uri/folder, then don't start a new one.
   if (clients.has(clientsKey)) {
     return;


### PR DESCRIPTION
Addresses issue #300

### How to test:

Set "Haskell: Ignore Standalone" option to `true`

![image](https://user-images.githubusercontent.com/7870080/109287218-5edb6080-7834-11eb-9091-22528c47e355.png)

Open Haskell project and check that there's only one HLS instance:

![image](https://user-images.githubusercontent.com/7870080/109287371-86322d80-7834-11eb-83fb-8c52c726fbc4.png)

Create a new standalone file (`Ctrl+N`) and paste some Haskell code from your project. Check that the number of `haskell*` processes is the same (i.e. extension haven't spawned any additional processes for this standalone file)