### PR TITLE
Filter third-party binaries from ghcup list output

### DIFF
--- a/src/ghcup.ts
+++ b/src/ghcup.ts
@@ -101,13 +101,23 @@ export class GHCup {
    */
   public async getAnyLatestVersion(tool: Tool): Promise<ToolInfo | null> {
     // these might be custom/stray/compiled, so we try first
-    const installedVersions = await this.listTool(tool, 'installed');
+    const installedVersions = await this.getAllInstalledVersions(tool);
     const latestInstalled = installedVersions.pop();
     if (latestInstalled) {
       return latestInstalled;
     } else {
       return this.getLatestAvailableVersion(tool);
     }
+  }
+
+  /**
+   * Find all installed versions of a {@link Tool} that we can find in GHCup.
+   *
+   * @param tool Tool you want to know which versions are installed of.
+   * @returns All installed versions of the {@link tool}
+   */
+  public async getAllInstalledVersions(tool: Tool): Promise<ToolInfo[]> {
+    return await this.listTool(tool, 'installed');
   }
 
   /**
@@ -138,22 +148,40 @@ export class GHCup {
   private async listTool(tool: Tool, category: string): Promise<ToolInfo[]> {
     // fall back to installable versions
     const availableVersions = await this.call(['list', '-t', tool, '-c', category, '-r'], undefined, false).then((s) =>
-      s.split(/\r?\n/),
+      // Split by newline and filter empty lines
+      s.split(/\r?\n/).filter((tool) => tool.length > 0),
     );
 
-    return availableVersions.map((toolString) => {
-      const toolParts = toolString.split(/\s+/);
-      return {
-        tool: tool,
-        version: toolParts[1],
-        tags: toolParts[2]?.split(',') ?? [],
-      };
-    });
+    return availableVersions
+      .map((toolString) => {
+        const toolParts = toolString.split(/\s+/);
+        return {
+          tool: tool,
+          version: toolParts[1],
+          tags: toolParts[2]?.split(',') ?? [],
+        };
+      })
+      .filter((tool) => {
+        // We check that the first character is a digit to filter out
+        // third-party channels binaries.
+        // Currently, third-party channels usually prefix their binary versions with a string:
+        //
+        //    > ghcup --no-verbose list -t ghc -c available -r
+        //    ...
+        //    ghc 9.14.1 latest,base-4.22.0.0 2025-12-18
+        //    ghc javascript-unknown-ghcjs-9.12.2 base-4.21.0.0
+        //
+        // A poor man's filter, but we have to wait for
+        // https://github.com/haskell/ghcup-hs/issues/1362
+        // to get something less hacky.
+        //
+        const c = tool.version.charAt(0);
+        return '0' <= c && c <= '9';
+      });
   }
 
   public async findLatestUserInstalledTool(tool: Tool): Promise<ToolInfo> {
-    let toolInfo = null;
-    toolInfo = await this.getSetVersion(tool);
+    let toolInfo = await this.getSetVersion(tool);
     if (toolInfo) return toolInfo;
     toolInfo = await this.getAnyLatestVersion(tool);
     if (toolInfo) return toolInfo;

--- a/src/hlsBinaries.ts
+++ b/src/hlsBinaries.ts
@@ -401,7 +401,7 @@ async function getLatestProjectHls(
   // first we get supported GHC versions from available HLS bindists (whether installed or not)
   const metadataMap = (await getHlsMetadata(storagePath, logger)) || new Map<string, string[]>();
   // then we get supported GHC versions from currently installed HLS versions
-  const ghcupMap = (await findAvailableHlsBinariesFromGHCup(ghcup)) || new Map<string, string[]>();
+  const ghcupMap = await findAvailableHlsBinariesFromGHCup(ghcup);
   // since installed HLS versions may support a different set of GHC versions than the bindists
   // (e.g. because the user ran 'ghcup compile hls'), we need to merge both maps, preferring
   // values from already installed HLSes
@@ -507,8 +507,8 @@ export function getStoragePath(context: ExtensionContext): string {
  * @returns A Map of the locally installed HLS versions and with which `GHC` versions they are compatible.
  */
 
-async function findAvailableHlsBinariesFromGHCup(ghcup: GHCup): Promise<Map<string, string[]> | null> {
-  const hlsVersions = await ghcup.call(['list', '-t', 'hls', '-c', 'installed', '-r'], undefined, false);
+async function findAvailableHlsBinariesFromGHCup(ghcup: GHCup): Promise<Map<string, string[]>> {
+  const hlsVersions = await ghcup.getAllInstalledVersions('hls');
 
   const bindir = await ghcup.call(['whereis', 'bindir'], undefined, false);
   const files = fs.readdirSync(bindir).filter((e) => {
@@ -516,22 +516,17 @@ async function findAvailableHlsBinariesFromGHCup(ghcup: GHCup): Promise<Map<stri
     return stat.isFile();
   });
 
-  const installed = hlsVersions.split(/\r?\n/).map((e) => e.split(/\s+/)[1]);
-  if (installed?.length) {
-    const myMap = new Map<string, string[]>();
-    installed.forEach((hls) => {
-      const ghcs = files
-        .filter((f) => f.endsWith(`~${hls}${exeExt}`) && f.startsWith('haskell-language-server-'))
-        .map((f) => {
-          const rmPrefix = f.substring('haskell-language-server-'.length);
-          return rmPrefix.substring(0, rmPrefix.length - `~${hls}${exeExt}`.length);
-        });
-      myMap.set(hls, ghcs);
-    });
-    return myMap;
-  } else {
-    return null;
-  }
+  const myMap = new Map<string, string[]>();
+  hlsVersions.forEach((hls) => {
+    const ghcs = files
+      .filter((f) => f.endsWith(`~${hls.version}${exeExt}`) && f.startsWith('haskell-language-server-'))
+      .map((f) => {
+        const rmPrefix = f.substring('haskell-language-server-'.length);
+        return rmPrefix.substring(0, rmPrefix.length - `~${hls.version}${exeExt}`.length);
+      });
+    myMap.set(hls.version, ghcs);
+  });
+  return myMap;
 }
 
 async function installationStatusOfGhcupTool(ghcup: GHCup, tool: Tool, version: string): Promise<ToolStatus> {


### PR DESCRIPTION
In recent ghcup versions, the output of `ghcup list -r` changed the order, listing third-party channel binaries last, instead of the binary with the highest versions.

    > ghcup --no-verbose list -t ghc -c available -r
    ...
    ghc 9.14.1 latest,base-4.22.0.0 2025-12-18
    ghc javascript-unknown-ghcjs-9.12.2 base-4.21.0.0

We fix this by checking whether the first character of the version is actually a digit. If not, we assume it is a binary from a third-party channel.

This extension works only with the non-cross-compiler binaries.

Closes #1374 